### PR TITLE
Fix issue #13

### DIFF
--- a/src/Packages/Microsoft.CodeDom.Providers.DotNetCompilerPlatform/build/Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props
+++ b/src/Packages/Microsoft.CodeDom.Providers.DotNetCompilerPlatform/build/Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props
@@ -4,20 +4,6 @@
       <Link>roslyn\%(RecursiveDir)%(Filename)%(Extension)</Link>
     </RoslyCompilerFiles>
   </ItemGroup>
-  <Target Name="RoslynCompilerFilesToPublish">
-    <ItemGroup>
-      <_RoslynFiles Include="@(RoslyCompilerFiles)" />
-      <FilesForPackagingFromProject Include="%(_RoslynFiles.Identity)">
-        <DestinationRelativePath>bin\roslyn\%(RecursiveDir)%(Filename)%(Extension)</DestinationRelativePath>
-      </FilesForPackagingFromProject>
-    </ItemGroup>
-  </Target>
-  <PropertyGroup>
-    <CopyAllFilesToSingleFolderForPackageDependsOn>
-      RoslynCompilerFilesToPublish;
-      $(CopyAllFilesToSingleFolderForPackageDependsOn);
-    </CopyAllFilesToSingleFolderForPackageDependsOn>
-  </PropertyGroup>
   <Target Name="IncludeRoslynCompilerFilesToFilesForPackagingFromProject" BeforeTargets="PrepareForRun" >
     <ItemGroup>
       <FilesForPackagingFromProject Include="@(RoslyCompilerFiles)">

--- a/src/Packages/Microsoft.CodeDom.Providers.DotNetCompilerPlatform/build/Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props
+++ b/src/Packages/Microsoft.CodeDom.Providers.DotNetCompilerPlatform/build/Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props
@@ -4,15 +4,6 @@
       <Link>roslyn\%(RecursiveDir)%(Filename)%(Extension)</Link>
     </RoslyCompilerFiles>
   </ItemGroup>
-  <Target Name="IncludeRoslynCompilerFilesToFilesForPackagingFromProject" AfterTargets="ConfigureFoldersForAspNetCompileMerge" >
-    <ItemGroup>
-      <FilesForPackagingFromProject Include="@(RoslyCompilerFiles)">
-        <DestinationRelativePath>bin\roslyn\%(RecursiveDir)%(Filename)%(Extension)</DestinationRelativePath>
-        <FromTarget>IncludeRoslynCompilerFilesToFilesForPackagingFromProject</FromTarget>
-        <Category>Run</Category>
-      </FilesForPackagingFromProject>
-    </ItemGroup>
-  </Target>
   <Target Name="RoslynCompilerFilesToPublish">
     <ItemGroup>
       <_RoslynFiles Include="@(RoslyCompilerFiles)" />
@@ -27,6 +18,15 @@
       $(CopyAllFilesToSingleFolderForPackageDependsOn);
     </CopyAllFilesToSingleFolderForPackageDependsOn>
   </PropertyGroup>
+  <Target Name="IncludeRoslynCompilerFilesToFilesForPackagingFromProject" BeforeTargets="PrepareForRun" >
+    <ItemGroup>
+      <FilesForPackagingFromProject Include="@(RoslyCompilerFiles)">
+        <DestinationRelativePath>bin\roslyn\%(RecursiveDir)%(Filename)%(Extension)</DestinationRelativePath>
+        <FromTarget>IncludeRoslynCompilerFilesToFilesForPackagingFromProject</FromTarget>
+        <Category>Run</Category>
+      </FilesForPackagingFromProject>
+    </ItemGroup>
+  </Target>
   <Target Name="CopyRoslynCompilerFilesToOutputDirectory" AfterTargets="CopyFilesToOutputDirectory">
     <Copy SourceFiles="@(RoslyCompilerFiles)" DestinationFolder="$(WebProjectOutputDir)\bin\roslyn" ContinueOnError="true" SkipUnchangedFiles="true" Retries="0" />
   </Target>

--- a/src/Packages/Microsoft.CodeDom.Providers.DotNetCompilerPlatform/build/Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props
+++ b/src/Packages/Microsoft.CodeDom.Providers.DotNetCompilerPlatform/build/Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props
@@ -4,7 +4,16 @@
       <Link>roslyn\%(RecursiveDir)%(Filename)%(Extension)</Link>
     </RoslyCompilerFiles>
   </ItemGroup>
- <Target Name="RoslynCompilerFilesToPublish">
+  <Target Name="IncludeRoslynCompilerFilesToFilesForPackagingFromProject" AfterTargets="ConfigureFoldersForAspNetCompileMerge" >
+    <ItemGroup>
+      <FilesForPackagingFromProject Include="@(RoslyCompilerFiles)">
+        <DestinationRelativePath>bin\roslyn\%(RecursiveDir)%(Filename)%(Extension)</DestinationRelativePath>
+        <FromTarget>IncludeRoslynCompilerFilesToFilesForPackagingFromProject</FromTarget>
+        <Category>Run</Category>
+      </FilesForPackagingFromProject>
+    </ItemGroup>
+  </Target>
+  <Target Name="RoslynCompilerFilesToPublish">
     <ItemGroup>
       <_RoslynFiles Include="@(RoslyCompilerFiles)" />
       <FilesForPackagingFromProject Include="%(_RoslynFiles.Identity)">

--- a/src/Packages/Microsoft.CodeDom.Providers.DotNetCompilerPlatform/content/net45/web.config.install.xdt
+++ b/src/Packages/Microsoft.CodeDom.Providers.DotNetCompilerPlatform/content/net45/web.config.install.xdt
@@ -26,7 +26,7 @@
       <compiler
         language="c#;cs;csharp"
         extension=".cs"
-        type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.CSharpCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.6.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35"
+        type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.CSharpCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.7.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35"
         warningLevel="4"
         compilerOptions="/langversion:6 /nowarn:1659;1699;1701"
         xdt:Transform="Insert" />
@@ -49,7 +49,7 @@
       <compiler
         language="vb;vbs;visualbasic;vbscript"
         extension=".vb"
-        type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.VBCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.6.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35"
+        type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.VBCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.7.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35"
         warningLevel="4"
         compilerOptions="/langversion:14 /nowarn:41008 /define:_MYTYPE=\&quot;Web\&quot; /optionInfer+"
         xdt:Transform="Insert" />

--- a/src/Packages/Microsoft.CodeDom.Providers.DotNetCompilerPlatform/content/net46/web.config.install.xdt
+++ b/src/Packages/Microsoft.CodeDom.Providers.DotNetCompilerPlatform/content/net46/web.config.install.xdt
@@ -26,7 +26,7 @@
       <compiler
         language="c#;cs;csharp"
         extension=".cs"
-        type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.CSharpCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.6.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35"
+        type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.CSharpCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.7.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35"
         warningLevel="4"
         compilerOptions="/langversion:default /nowarn:1659;1699;1701"
         xdt:Transform="Insert" />
@@ -49,7 +49,7 @@
       <compiler
         language="vb;vbs;visualbasic;vbscript"
         extension=".vb"
-        type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.VBCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.6.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35"
+        type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.VBCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.7.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35"
         warningLevel="4"
         compilerOptions="/langversion:default /nowarn:41008 /define:_MYTYPE=\&quot;Web\&quot; /optionInfer+"
         xdt:Transform="Insert" />

--- a/tools/RoslynCodeProvider.settings.targets
+++ b/tools/RoslynCodeProvider.settings.targets
@@ -6,7 +6,7 @@
         <VersionStartYear>2014</VersionStartYear>
         <VersionMajor>1</VersionMajor>
         <VersionMinor>0</VersionMinor>
-        <VersionRelease>6</VersionRelease>
+        <VersionRelease>7</VersionRelease>
         <VersionRelease Condition="'$(BuildQuality)' != 'rtm'">$(VersionRelease)-$(BuildQuality)</VersionRelease>
     </PropertyGroup>
 


### PR DESCRIPTION
In 1.0.6 release, the change made in Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props broke the publish scenarios(using merge in publish & webdeploy publish). The fix is to include the Rolsyn files into FilesForPackagingFromProject  ItemGroup which is used to store all the files to be published.