### PR TITLE
Dev remove roslyn nupkg ref

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ PublishProfiles/
 .build/
 .testPublish/
 msbuild.*
+src/**/tools/Roslyn*/

--- a/src/Packages/Microsoft.CodeDom.Providers.DotNetCompilerPlatform/Microsoft.CodeDom.Providers.DotNetCompilerPlatform.nuproj
+++ b/src/Packages/Microsoft.CodeDom.Providers.DotNetCompilerPlatform/Microsoft.CodeDom.Providers.DotNetCompilerPlatform.nuproj
@@ -29,8 +29,23 @@
         <NuGetContent Include="build\*">
             <Destination>build\net45</Destination>
         </NuGetContent>
+        <NuGetContent Include="build\*">
+            <Destination>build\net46</Destination>
+        </NuGetContent>
+        <NuGetContent Include="build\net45\*">
+            <Destination>build\net45</Destination>
+        </NuGetContent>
+        <NuGetContent Include="build\net46\*">
+            <Destination>build\net46</Destination>
+        </NuGetContent>
         <NuGetContent Include="tools\*.ps1">
             <Destination>tools\net45</Destination>
+        </NuGetContent>
+        <NuGetContent Include="tools\$(LocalRoslynFolderName)\*">
+            <Destination>tools\$(LocalRoslynFolderName)</Destination>
+        </NuGetContent>
+        <NuGetContent Include="tools\$(LocalLatestRoslynFolderName)\*">
+            <Destination>tools\$(LocalLatestRoslynFolderName)</Destination>
         </NuGetContent>
     </ItemGroup>
     <Import Project="$(RepositoryRoot)Tools\NuGetProj.targets"/>

--- a/src/Packages/Microsoft.CodeDom.Providers.DotNetCompilerPlatform/Microsoft.CodeDom.Providers.DotNetCompilerPlatform.nuspec
+++ b/src/Packages/Microsoft.CodeDom.Providers.DotNetCompilerPlatform/Microsoft.CodeDom.Providers.DotNetCompilerPlatform.nuspec
@@ -14,13 +14,5 @@
         <licenseUrl>http://www.microsoft.com/web/webpi/eula/net_library_eula_ENU.htm</licenseUrl>
         <requireLicenseAcceptance>true</requireLicenseAcceptance>
         <tags>Roslyn CodeDOM Compiler CSharp VB.Net ASP.NET</tags>
-        <dependencies>
-            <group targetFramework=".NETFramework4.5">
-                <dependency id="Microsoft.Net.Compilers" version="$MSNetCompilersNuGetPackageVersion$" />
-            </group>
-            <group targetFramework=".NETFramework4.6">
-                <dependency id="Microsoft.Net.Compilers" version="$MSNetCompilersNuGetPackageLatestVersion$" />
-            </group>
-        </dependencies>
     </metadata>
 </package>

--- a/src/Packages/Microsoft.CodeDom.Providers.DotNetCompilerPlatform/build/Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props
+++ b/src/Packages/Microsoft.CodeDom.Providers.DotNetCompilerPlatform/build/Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props
@@ -1,6 +1,8 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.Extensions.props"/>
+
   <ItemGroup>
-    <RoslyCompilerFiles Include="$(CscToolPath)\*">
+    <RoslyCompilerFiles Include="$(RoslynToolPath)\*">
       <Link>roslyn\%(RecursiveDir)%(Filename)%(Extension)</Link>
     </RoslyCompilerFiles>
   </ItemGroup>

--- a/src/Packages/Microsoft.CodeDom.Providers.DotNetCompilerPlatform/build/net45/Microsoft.CodeDom.Providers.DotNetCompilerPlatform.Extensions.props
+++ b/src/Packages/Microsoft.CodeDom.Providers.DotNetCompilerPlatform/build/net45/Microsoft.CodeDom.Providers.DotNetCompilerPlatform.Extensions.props
@@ -1,0 +1,6 @@
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <RoslynToolPath Condition=" '$(UseRoslynPackage)' == '' ">$(MSBuildThisFileDirectory)..\..\tools\roslyn45</RoslynToolPath>
+    <RoslynToolPath Condition=" '$(UseRoslynPackage)' != '' ">$(CscToolPath)</RoslynToolPath>
+  </PropertyGroup>
+  </Project>

--- a/src/Packages/Microsoft.CodeDom.Providers.DotNetCompilerPlatform/build/net45/Microsoft.CodeDom.Providers.DotNetCompilerPlatform.Extensions.props
+++ b/src/Packages/Microsoft.CodeDom.Providers.DotNetCompilerPlatform/build/net45/Microsoft.CodeDom.Providers.DotNetCompilerPlatform.Extensions.props
@@ -1,6 +1,5 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <RoslynToolPath Condition=" '$(UseRoslynPackage)' == '' ">$(MSBuildThisFileDirectory)..\..\tools\roslyn45</RoslynToolPath>
-    <RoslynToolPath Condition=" '$(UseRoslynPackage)' != '' ">$(CscToolPath)</RoslynToolPath>
+    <RoslynToolPath Condition=" '$(RoslynToolPath)' == '' ">$(MSBuildThisFileDirectory)..\..\tools\roslyn45</RoslynToolPath>
   </PropertyGroup>
   </Project>

--- a/src/Packages/Microsoft.CodeDom.Providers.DotNetCompilerPlatform/build/net46/Microsoft.CodeDom.Providers.DotNetCompilerPlatform.Extensions.props
+++ b/src/Packages/Microsoft.CodeDom.Providers.DotNetCompilerPlatform/build/net46/Microsoft.CodeDom.Providers.DotNetCompilerPlatform.Extensions.props
@@ -1,0 +1,6 @@
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <RoslynToolPath Condition=" '$(UseRoslynPackage)' == '' ">$(MSBuildThisFileDirectory)..\..\tools\roslynlatest</RoslynToolPath>
+    <RoslynToolPath Condition=" '$(UseRoslynPackage)' != '' ">$(CscToolPath)</RoslynToolPath>
+  </PropertyGroup>
+  </Project>

--- a/src/Packages/Microsoft.CodeDom.Providers.DotNetCompilerPlatform/build/net46/Microsoft.CodeDom.Providers.DotNetCompilerPlatform.Extensions.props
+++ b/src/Packages/Microsoft.CodeDom.Providers.DotNetCompilerPlatform/build/net46/Microsoft.CodeDom.Providers.DotNetCompilerPlatform.Extensions.props
@@ -1,6 +1,5 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <RoslynToolPath Condition=" '$(UseRoslynPackage)' == '' ">$(MSBuildThisFileDirectory)..\..\tools\roslynlatest</RoslynToolPath>
-    <RoslynToolPath Condition=" '$(UseRoslynPackage)' != '' ">$(CscToolPath)</RoslynToolPath>
+    <RoslynToolPath Condition=" '$(RoslynToolPath)' == '' ">$(MSBuildThisFileDirectory)..\..\tools\roslynlatest</RoslynToolPath>
   </PropertyGroup>
   </Project>

--- a/src/Packages/Microsoft.CodeDom.Providers.DotNetCompilerPlatform/content/net45/web.config.install.xdt
+++ b/src/Packages/Microsoft.CodeDom.Providers.DotNetCompilerPlatform/content/net45/web.config.install.xdt
@@ -26,7 +26,7 @@
       <compiler
         language="c#;cs;csharp"
         extension=".cs"
-        type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.CSharpCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.8.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35"
+        type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.CSharpCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.9.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35"
         warningLevel="4"
         compilerOptions="/langversion:6 /nowarn:1659;1699;1701"
         xdt:Transform="Insert" />
@@ -49,7 +49,7 @@
       <compiler
         language="vb;vbs;visualbasic;vbscript"
         extension=".vb"
-        type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.VBCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.8.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35"
+        type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.VBCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.9.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35"
         warningLevel="4"
         compilerOptions="/langversion:14 /nowarn:41008 /define:_MYTYPE=\&quot;Web\&quot; /optionInfer+"
         xdt:Transform="Insert" />

--- a/src/Packages/Microsoft.CodeDom.Providers.DotNetCompilerPlatform/content/net46/web.config.install.xdt
+++ b/src/Packages/Microsoft.CodeDom.Providers.DotNetCompilerPlatform/content/net46/web.config.install.xdt
@@ -26,7 +26,7 @@
       <compiler
         language="c#;cs;csharp"
         extension=".cs"
-        type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.CSharpCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.8.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35"
+        type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.CSharpCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.9.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35"
         warningLevel="4"
         compilerOptions="/langversion:default /nowarn:1659;1699;1701"
         xdt:Transform="Insert" />
@@ -49,7 +49,7 @@
       <compiler
         language="vb;vbs;visualbasic;vbscript"
         extension=".vb"
-        type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.VBCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.8.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35"
+        type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.VBCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.9.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35"
         warningLevel="4"
         compilerOptions="/langversion:default /nowarn:41008 /define:_MYTYPE=\&quot;Web\&quot; /optionInfer+"
         xdt:Transform="Insert" />

--- a/tools/RoslynCodeProvider.Extensions.targets
+++ b/tools/RoslynCodeProvider.Extensions.targets
@@ -1,18 +1,82 @@
 <Project DefaultTargets="UnitTest" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-
-    <!-- Update NuGet Package version for nightly build-->
-    <PropertyGroup Condition="'$(MSBuildProjectExtension)' == '.nuproj'">
-        <NuGetPackageVersion Condition="'$(UpdateNightlyPackages)' == 'true'">$(NuGetPackageVersion)-b$(VersionBuild)</NuGetPackageVersion>
+    <PropertyGroup>
+        <NupkgToolPath>$(RepositoryRoot)src\Packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform\tools\</NupkgToolPath>
+        <LocalRoslynFolderName>Roslyn45</LocalRoslynFolderName>
+        <LocalLatestRoslynFolderName>RoslynLatest</LocalLatestRoslynFolderName>
     </PropertyGroup>
-  
-    <ItemGroup>
-      <NuGetInstallScripts Include="$(RepositoryRootEx)src\Packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform\tools\*.ps1"/>
-    </ItemGroup>
-
-    <Target Name="CopyInstallScripts">
-        <Copy SourceFiles="@(NuGetInstallScripts)"
-              DestinationFolder="$(AssemblyPath)"
-        />
-    </Target>
     
+    <UsingTask TaskName="DownloadRoslynBinaries" TaskFactory="CodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v4.0.dll">
+    <ParameterGroup>
+      <NupkgToolPath ParameterType="System.String" Required="true" />
+      <LocalRoslynFolderName ParameterType="System.String" Required="true" />
+      <LocalLatestRoslynFolderName ParameterType="System.String" Required="true" />
+      <ReferenceRoslynNupkgVersion ParameterType="System.String" Required="true" />
+      <ReferenceLatestRoslynNupkgVersion ParameterType="System.String" Required="true" />
+    </ParameterGroup>
+    <Task>
+      <Reference Include="System" />
+      <Reference Include="System.IO.Compression.FileSystem" />
+      <Using Namespace="System.IO" />
+      <Using Namespace="System.IO.Compression" />
+      <Using Namespace="System.Net" />
+      <Code Type="Fragment" Language="cs">
+        <![CDATA[
+                try
+                {
+                   using (var wc = new WebClient())
+                    {
+                        var roslynNugetBaseUri = "https://api.nuget.org/packages/microsoft.net.compilers.{0}.nupkg";
+                        var roslynPackageName = "microsoft.net.compilers.{0}.nupkg";
+
+                        var targetFilePath = Path.Combine(Path.GetTempPath(), string.Format(roslynPackageName, ReferenceRoslynNupkgVersion));
+                        var targetExtractPath = Path.Combine(Path.GetTempPath(), LocalRoslynFolderName);
+                        var targetPath = Path.Combine(NupkgToolPath, LocalRoslynFolderName);
+                        if (Directory.Exists(targetExtractPath))
+                        {
+                            Directory.Delete(targetExtractPath, true);
+                        }
+                        if (Directory.Exists(targetPath))
+                        {
+                            Directory.Delete(targetPath, true);
+                        }
+
+                        wc.DownloadFile(string.Format(roslynNugetBaseUri, ReferenceRoslynNupkgVersion), targetFilePath);
+                        ZipFile.ExtractToDirectory(targetFilePath, targetExtractPath);
+                        Directory.CreateDirectory(targetPath);
+                        foreach(var file in Directory.GetFiles(Path.Combine(targetExtractPath, "tools"))){
+                            var fi = new FileInfo(file);
+                            File.Copy(file, Path.Combine(targetPath, fi.Name));
+                        }
+
+                        targetFilePath = Path.Combine(Path.GetTempPath(), string.Format(roslynPackageName, ReferenceLatestRoslynNupkgVersion));
+                        targetExtractPath = Path.Combine(Path.GetTempPath(), LocalLatestRoslynFolderName);
+                        targetPath = Path.Combine(NupkgToolPath, LocalLatestRoslynFolderName);
+                        if (Directory.Exists(targetExtractPath))
+                        {
+                            Directory.Delete(targetExtractPath, true);
+                        }
+                        if (Directory.Exists(targetPath))
+                        {
+                            Directory.Delete(targetPath, true);
+                        }
+
+                        wc.DownloadFile(string.Format(roslynNugetBaseUri, ReferenceLatestRoslynNupkgVersion), targetFilePath);
+                        ZipFile.ExtractToDirectory(targetFilePath, targetExtractPath);
+                        Directory.CreateDirectory(targetPath);
+                        foreach (var file in Directory.GetFiles(Path.Combine(targetExtractPath, "tools")))
+                        {
+                            var fi = new FileInfo(file);
+                            File.Copy(file, Path.Combine(targetPath, fi.Name));
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                  Log.LogErrorFromException(ex);
+                }
+                return true;
+                ]]>
+      </Code>
+    </Task>
+  </UsingTask>
 </Project>

--- a/tools/RoslynCodeProvider.settings.targets
+++ b/tools/RoslynCodeProvider.settings.targets
@@ -1,4 +1,5 @@
 <Project DefaultTargets="UnitTest" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
     <!-- Configurable properties-->
 
     <PropertyGroup>
@@ -6,7 +7,7 @@
         <VersionStartYear>2014</VersionStartYear>
         <VersionMajor>1</VersionMajor>
         <VersionMinor>0</VersionMinor>
-        <VersionRelease>8</VersionRelease>
+        <VersionRelease>9</VersionRelease>
         <VersionRelease Condition="'$(BuildQuality)' != 'rtm'">$(VersionRelease)-$(BuildQuality)</VersionRelease>
     </PropertyGroup>
 

--- a/tools/RoslynCodeProvider.targets
+++ b/tools/RoslynCodeProvider.targets
@@ -2,10 +2,11 @@
 
     <!-- Build order -->
     <PropertyGroup>
-        <BuildDependsOn>SetNuSpecProperties;$(BuildDependsOn)</BuildDependsOn>
+        <BuildDependsOn>SetNuSpecProperties;DownloadRoslynBinariesToToolsFolder;$(BuildDependsOn)</BuildDependsOn>
     </PropertyGroup>
 
     <Import Project="$(MSBuildThisFileDirectory)version.targets"/>
+    <Import Project="$(MSBuildThisFileDirectory)RoslynCodeProvider.Extensions.targets"/>
 
     <!-- Post-targets computed properties. -->
 
@@ -22,9 +23,12 @@
             <NuSpecProperties>
                 NuGetPackageVersion=$(NuGetPackageVersion);
                 NuGetPackageId=$(NuGetPackageId);
-                MSNetCompilersNuGetPackageVersion=$(MSNetCompilersNuGetPackageVersion);
-                MSNetCompilersNuGetPackageLatestVersion=$(MSNetCompilersNuGetPackageLatestVersion)
             </NuSpecProperties>
         </PropertyGroup>
+    </Target>
+
+    <Target Name="DownloadRoslynBinariesToToolsFolder">
+        <DownloadRoslynBinaries NupkgToolPath="$(NupkgToolPath)" LocalRoslynFolderName="$(LocalRoslynFolderName)" LocalLatestRoslynFolderName="$(LocalLatestRoslynFolderName)" 
+            ReferenceRoslynNupkgVersion="$(MSNetCompilersNuGetPackageVersion)" ReferenceLatestRoslynNupkgVersion="$(MSNetCompilersNuGetPackageLatestVersion)" />
     </Target>
 </Project>


### PR DESCRIPTION
Remove the dependency of Microsoft.Net.Compilers nupkg, instead embed the Roslyn bits inside CodeDomProvider nupkg. This will ensure VS always use the Roslyn compiler shipped with msbuild. Developer can also specify a path through the following msbuild property from which CodeDomProvider copies the Roslyn compilers to bin\roslyn folder.

 <PropertyGroup>
     <RoslynToolPath>[some path]</RoslynToolPath>
 <PropertyGroup>