### PR TITLE
add support for non web proj

### DIFF
--- a/src/Microsoft.CodeDom.Providers.DotNetCompilerPlatform/AppSettings.cs
+++ b/src/Microsoft.CodeDom.Providers.DotNetCompilerPlatform/AppSettings.cs
@@ -20,6 +20,8 @@ namespace Microsoft.CodeDom.Providers.DotNetCompilerPlatform {
             if (!bool.TryParse(disableProfilingDuringCompilation, out _disableProfilingDuringCompilation)) {
                 _disableProfilingDuringCompilation = true;
             }
+
+            _roslynCompilerLocation =  appSettings["aspnet:RoslynCompilerLocation"];
         }
 
         private static void EnsureSettingsLoaded() {
@@ -44,6 +46,14 @@ namespace Microsoft.CodeDom.Providers.DotNetCompilerPlatform {
             get {
                 EnsureSettingsLoaded();
                 return _disableProfilingDuringCompilation;
+            }
+        }
+
+        private static string _roslynCompilerLocation = string.Empty;
+        public static string RoslynCompilerLocation {
+            get {
+                EnsureSettingsLoaded();
+                return _roslynCompilerLocation;
             }
         }
     }

--- a/src/Microsoft.CodeDom.Providers.DotNetCompilerPlatform/Util/CompilationSettings.cs
+++ b/src/Microsoft.CodeDom.Providers.DotNetCompilerPlatform/Util/CompilationSettings.cs
@@ -71,8 +71,14 @@ namespace Microsoft.CodeDom.Providers.DotNetCompilerPlatform {
                 }
             }
 
+            // locate Roslyn compilers order: 1. environment variable  2. appsetting  3. default location
             var customRoslynCompilerLocation = Environment.GetEnvironmentVariable(CustomRoslynCompilerLocation, EnvironmentVariableTarget.Process);
-            if(customRoslynCompilerLocation != null)
+            if(string.IsNullOrEmpty(customRoslynCompilerLocation))
+            {
+                customRoslynCompilerLocation = AppSettings.RoslynCompilerLocation;
+            }
+
+            if(!string.IsNullOrEmpty(customRoslynCompilerLocation))
             {
                 _csc = new CompilerSettings($"{customRoslynCompilerLocation}\\csc.exe", ttl);
                 _vb = new CompilerSettings($"{customRoslynCompilerLocation}\\vbc.exe", ttl);

--- a/src/Packages/Microsoft.CodeDom.Providers.DotNetCompilerPlatform/build/Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props
+++ b/src/Packages/Microsoft.CodeDom.Providers.DotNetCompilerPlatform/build/Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props
@@ -1,10 +1,6 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.Extensions.props"/>
 
-  <PropertyGroup>
-      <RoslynToolsDestinationFolder>$(WebProjectOutputDir)\bin\roslyn</RoslynToolsDestinationFolder>
-  </PropertyGroup>
-
   <ItemGroup>
     <RoslyCompilerFiles Include="$(RoslynToolPath)\*">
       <Link>roslyn\%(RecursiveDir)%(Filename)%(Extension)</Link>
@@ -21,6 +17,7 @@
   </Target>
   <Target Name="CopyRoslynCompilerFilesToOutputDirectory" AfterTargets="CopyFilesToOutputDirectory">
     <PropertyGroup>
+      <RoslynToolsDestinationFolder>$(WebProjectOutputDir)\bin\roslyn</RoslynToolsDestinationFolder>
       <RoslynToolsDestinationFolder Condition=" '$(WebProjectOutputDir)' == '' ">$(OutputPath)\roslyn</RoslynToolsDestinationFolder>
     </PropertyGroup>
     <Copy SourceFiles="@(RoslyCompilerFiles)" DestinationFolder="$(RoslynToolsDestinationFolder)" ContinueOnError="true" SkipUnchangedFiles="true" Retries="0" />

--- a/src/Packages/Microsoft.CodeDom.Providers.DotNetCompilerPlatform/build/Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props
+++ b/src/Packages/Microsoft.CodeDom.Providers.DotNetCompilerPlatform/build/Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props
@@ -1,6 +1,10 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.Extensions.props"/>
 
+  <PropertyGroup>
+      <RoslynToolsDestinationFolder>$(WebProjectOutputDir)\bin\roslyn</RoslynToolsDestinationFolder>
+  </PropertyGroup>
+
   <ItemGroup>
     <RoslyCompilerFiles Include="$(RoslynToolPath)\*">
       <Link>roslyn\%(RecursiveDir)%(Filename)%(Extension)</Link>
@@ -16,16 +20,19 @@
     </ItemGroup>
   </Target>
   <Target Name="CopyRoslynCompilerFilesToOutputDirectory" AfterTargets="CopyFilesToOutputDirectory">
-    <Copy SourceFiles="@(RoslyCompilerFiles)" DestinationFolder="$(WebProjectOutputDir)\bin\roslyn" ContinueOnError="true" SkipUnchangedFiles="true" Retries="0" />
+    <PropertyGroup>
+      <RoslynToolsDestinationFolder Condition=" '$(WebProjectOutputDir)' == '' ">$(OutputPath)\roslyn</RoslynToolsDestinationFolder>
+    </PropertyGroup>
+    <Copy SourceFiles="@(RoslyCompilerFiles)" DestinationFolder="$(RoslynToolsDestinationFolder)" ContinueOnError="true" SkipUnchangedFiles="true" Retries="0" />
     <ItemGroup  Condition="'$(MSBuildLastTaskResult)' == 'True'" >
-      <FileWrites Include="$(WebProjectOutputDir)\bin\roslyn\*" />
+      <FileWrites Include="$(RoslynToolsDestinationFolder)\*" />
     </ItemGroup>
   </Target>
   <Target Name = "KillVBCSCompilerAndRetryCopy" AfterTargets="CopyRoslynCompilerFilesToOutputDirectory" Condition="'$(MSBuildLastTaskResult)' == 'False'" >
-    <KillProcess ProcessName="VBCSCompiler" ImagePath="$(WebProjectOutputDir)" />
-    <Copy SourceFiles="@(RoslyCompilerFiles)" DestinationFolder="$(WebProjectOutputDir)\bin\roslyn" ContinueOnError="true" SkipUnchangedFiles="true" />
+    <KillProcess ProcessName="VBCSCompiler" ImagePath="$(RoslynToolsDestinationFolder)" />
+    <Copy SourceFiles="@(RoslyCompilerFiles)" DestinationFolder="$(RoslynToolsDestinationFolder)" ContinueOnError="true" SkipUnchangedFiles="true" />
     <ItemGroup>
-      <FileWrites Include="$(WebProjectOutputDir)\bin\roslyn\*" />
+      <FileWrites Include="$(RoslynToolsDestinationFolder)\*" />
     </ItemGroup>
   </Target>
   <UsingTask TaskName="KillProcess" TaskFactory="CodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v4.0.dll">

--- a/src/Packages/Microsoft.CodeDom.Providers.DotNetCompilerPlatform/content/net45/app.config.install.xdt
+++ b/src/Packages/Microsoft.CodeDom.Providers.DotNetCompilerPlatform/content/net45/app.config.install.xdt
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
+  <appSettings xdt:Transform="InsertIfMissing">
+  </appSettings>
+
+  <appSettings>
+    <add key="aspnet:RoslynCompilerLocation" xdt:Transform="Remove" xdt:Locator="Match(key)" />
+    <add key="aspnet:RoslynCompilerLocation" value="roslyn" xdt:Transform="Insert" />
+  </appSettings>
+
+  <!-- If system.codedom tag is absent -->
+  <system.codedom xdt:Transform="InsertIfMissing">
+  </system.codedom>
+
+  <!-- If compilers tag is absent -->
+  <system.codedom>
+    <compilers xdt:Transform="InsertIfMissing">
+    </compilers>
+  </system.codedom>
+
+  <!-- If a .cs compiler is already present, the existing entry needs to be removed before inserting the new entry -->
+  <system.codedom>
+    <compilers>
+      <compiler
+        extension=".cs"
+        xdt:Transform="Remove"
+        xdt:Locator="Match(extension)" />
+    </compilers>
+  </system.codedom>
+
+  <!-- Inserting the new compiler -->
+  <system.codedom>
+    <compilers>
+      <compiler
+        language="c#;cs;csharp"
+        extension=".cs"
+        type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.CSharpCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.9.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35"
+        warningLevel="4"
+        compilerOptions="/langversion:6 /nowarn:1659;1699;1701"
+        xdt:Transform="Insert" />
+    </compilers>
+  </system.codedom>
+
+  <!-- If a .vb compiler is already present, the existing entry needs to be removed before inserting the new entry -->
+  <system.codedom>
+    <compilers>
+      <compiler
+        extension=".vb"
+        xdt:Transform="Remove"
+        xdt:Locator="Match(extension)" />
+    </compilers>
+  </system.codedom>
+
+  <!-- Inserting the new compiler -->
+  <system.codedom>
+    <compilers>
+      <compiler
+        language="vb;vbs;visualbasic;vbscript"
+        extension=".vb"
+        type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.VBCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.9.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35"
+        warningLevel="4"
+        compilerOptions="/langversion:14 /nowarn:41008 /define:_MYTYPE=\&quot;Web\&quot; /optionInfer+"
+        xdt:Transform="Insert" />
+    </compilers>
+  </system.codedom>
+</configuration>

--- a/src/Packages/Microsoft.CodeDom.Providers.DotNetCompilerPlatform/content/net45/app.config.uninstall.xdt
+++ b/src/Packages/Microsoft.CodeDom.Providers.DotNetCompilerPlatform/content/net45/app.config.uninstall.xdt
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
+  <appSettings>
+    <add key="aspnet:RoslynCompilerLocation" value="roslyn" xdt:Transform="Remove" xdt:Locator="Match(key)" />
+  </appSettings>
+  <appSettings xdt:Transform="Remove" xdt:Locator="Condition(count(child::*) = 0)">
+  </appSettings>
+
+  <system.codedom>
+    <compilers>
+      <compiler
+        extension=".cs"
+        xdt:Transform="Remove"
+        xdt:Locator="Match(extension)" />
+    </compilers>
+  </system.codedom>
+  <system.codedom>
+    <compilers>
+      <compiler
+        extension=".vb"
+        xdt:Transform="Remove"
+        xdt:Locator="Match(extension)" />
+    </compilers>
+  </system.codedom>
+  <system.codedom>
+    <compilers xdt:Transform="Remove" xdt:Locator="Condition(count(child::*) = 0)" />
+  </system.codedom>
+  <system.codedom xdt:Transform="Remove" xdt:Locator="Condition(count(child::*) = 0)" />
+</configuration>

--- a/src/Packages/Microsoft.CodeDom.Providers.DotNetCompilerPlatform/content/net46/app.config.install.xdt
+++ b/src/Packages/Microsoft.CodeDom.Providers.DotNetCompilerPlatform/content/net46/app.config.install.xdt
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
+  <appSettings xdt:Transform="InsertIfMissing">
+  </appSettings>
+
+  <appSettings>
+    <add key="aspnet:RoslynCompilerLocation" xdt:Transform="Remove" xdt:Locator="Match(key)" />
+    <add key="aspnet:RoslynCompilerLocation" value="roslyn" xdt:Transform="Insert" />
+  </appSettings>
+
+  <!-- If system.codedom tag is absent -->
+  <system.codedom xdt:Transform="InsertIfMissing">
+  </system.codedom>
+
+  <!-- If compilers tag is absent -->
+  <system.codedom>
+    <compilers xdt:Transform="InsertIfMissing">
+    </compilers>
+  </system.codedom>
+
+  <!-- If a .cs compiler is already present, the existing entry needs to be removed before inserting the new entry -->
+  <system.codedom>
+    <compilers>
+      <compiler
+        extension=".cs"
+        xdt:Transform="Remove"
+        xdt:Locator="Match(extension)" />
+    </compilers>
+  </system.codedom>
+
+  <!-- Inserting the new compiler -->
+  <system.codedom>
+    <compilers>
+      <compiler
+        language="c#;cs;csharp"
+        extension=".cs"
+        type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.CSharpCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.9.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35"
+        warningLevel="4"
+        compilerOptions="/langversion:default /nowarn:1659;1699;1701"
+        xdt:Transform="Insert" />
+    </compilers>
+  </system.codedom>
+
+  <!-- If a .vb compiler is already present, the existing entry needs to be removed before inserting the new entry -->
+  <system.codedom>
+    <compilers>
+      <compiler
+        extension=".vb"
+        xdt:Transform="Remove"
+        xdt:Locator="Match(extension)" />
+    </compilers>
+  </system.codedom>
+
+  <!-- Inserting the new compiler -->
+  <system.codedom>
+    <compilers>
+      <compiler
+        language="vb;vbs;visualbasic;vbscript"
+        extension=".vb"
+        type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.VBCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.9.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35"
+        warningLevel="4"
+        compilerOptions="/langversion:default /nowarn:41008 /define:_MYTYPE=\&quot;Web\&quot; /optionInfer+"
+        xdt:Transform="Insert" />
+    </compilers>
+  </system.codedom>
+</configuration>

--- a/src/Packages/Microsoft.CodeDom.Providers.DotNetCompilerPlatform/content/net46/app.config.uninstall.xdt
+++ b/src/Packages/Microsoft.CodeDom.Providers.DotNetCompilerPlatform/content/net46/app.config.uninstall.xdt
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
+  <appSettings>
+    <add key="aspnet:RoslynCompilerLocation" value="roslyn" xdt:Transform="Remove" xdt:Locator="Match(key)" />
+  </appSettings>
+  <appSettings xdt:Transform="Remove" xdt:Locator="Condition(count(child::*) = 0)">
+  </appSettings>
+
+  <system.codedom>
+    <compilers>
+      <compiler
+        extension=".cs"
+        xdt:Transform="Remove"
+        xdt:Locator="Match(extension)" />
+    </compilers>
+  </system.codedom>
+  <system.codedom>
+    <compilers>
+      <compiler
+        extension=".vb"
+        xdt:Transform="Remove"
+        xdt:Locator="Match(extension)" />
+    </compilers>
+  </system.codedom>
+  <system.codedom>
+    <compilers xdt:Transform="Remove" xdt:Locator="Condition(count(child::*) = 0)" />
+  </system.codedom>
+  <system.codedom xdt:Transform="Remove" xdt:Locator="Condition(count(child::*) = 0)" />
+</configuration>

--- a/tools/RoslynCodeProvider.Extensions.targets
+++ b/tools/RoslynCodeProvider.Extensions.targets
@@ -30,49 +30,54 @@
 
                         var targetFilePath = Path.Combine(Path.GetTempPath(), string.Format(roslynPackageName, ReferenceRoslynNupkgVersion));
                         var targetExtractPath = Path.Combine(Path.GetTempPath(), LocalRoslynFolderName);
-                        var targetPath = Path.Combine(NupkgToolPath, LocalRoslynFolderName);
+                        var packageToolsPath = Path.Combine(NupkgToolPath, LocalRoslynFolderName);
                         if (Directory.Exists(targetExtractPath))
                         {
                             Directory.Delete(targetExtractPath, true);
                         }
-                        if (Directory.Exists(targetPath))
+                        if (Directory.Exists(packageToolsPath))
                         {
-                            Directory.Delete(targetPath, true);
+                            Directory.Delete(packageToolsPath, true);
                         }
 
                         wc.DownloadFile(string.Format(roslynNugetBaseUri, ReferenceRoslynNupkgVersion), targetFilePath);
+                        Log.LogMessage("Microsoft.Net.Compilers.{0}.nupkg is downloaded", ReferenceRoslynNupkgVersion);
+                        
                         ZipFile.ExtractToDirectory(targetFilePath, targetExtractPath);
-                        Directory.CreateDirectory(targetPath);
+                        Directory.CreateDirectory(packageToolsPath);
                         foreach(var file in Directory.GetFiles(Path.Combine(targetExtractPath, "tools"))){
                             var fi = new FileInfo(file);
-                            File.Copy(file, Path.Combine(targetPath, fi.Name));
+                            File.Copy(file, Path.Combine(packageToolsPath, fi.Name));
                         }
 
                         targetFilePath = Path.Combine(Path.GetTempPath(), string.Format(roslynPackageName, ReferenceLatestRoslynNupkgVersion));
                         targetExtractPath = Path.Combine(Path.GetTempPath(), LocalLatestRoslynFolderName);
-                        targetPath = Path.Combine(NupkgToolPath, LocalLatestRoslynFolderName);
+                        packageToolsPath = Path.Combine(NupkgToolPath, LocalLatestRoslynFolderName);
                         if (Directory.Exists(targetExtractPath))
                         {
                             Directory.Delete(targetExtractPath, true);
                         }
-                        if (Directory.Exists(targetPath))
+                        if (Directory.Exists(packageToolsPath))
                         {
-                            Directory.Delete(targetPath, true);
+                            Directory.Delete(packageToolsPath, true);
                         }
 
                         wc.DownloadFile(string.Format(roslynNugetBaseUri, ReferenceLatestRoslynNupkgVersion), targetFilePath);
+                        Log.LogMessage("Microsoft.Net.Compilers.{0}.nupkg is downloaded", ReferenceLatestRoslynNupkgVersion);
+
                         ZipFile.ExtractToDirectory(targetFilePath, targetExtractPath);
-                        Directory.CreateDirectory(targetPath);
+                        Directory.CreateDirectory(packageToolsPath);
                         foreach (var file in Directory.GetFiles(Path.Combine(targetExtractPath, "tools")))
                         {
                             var fi = new FileInfo(file);
-                            File.Copy(file, Path.Combine(targetPath, fi.Name));
+                            File.Copy(file, Path.Combine(packageToolsPath, fi.Name));
                         }
                     }
                 }
                 catch (Exception ex)
                 {
                   Log.LogErrorFromException(ex);
+                  return false;
                 }
                 return true;
                 ]]>

--- a/tools/RoslynCodeProvider.settings.targets
+++ b/tools/RoslynCodeProvider.settings.targets
@@ -13,7 +13,7 @@
 
     <PropertyGroup Label="NuGet package dependencies">
         <MSNetCompilersNuGetPackageVersion>1.3.2</MSNetCompilersNuGetPackageVersion>
-        <MSNetCompilersNuGetPackageLatestVersion>2.4.0</MSNetCompilersNuGetPackageLatestVersion>
+        <MSNetCompilersNuGetPackageLatestVersion>2.6.1</MSNetCompilersNuGetPackageLatestVersion>
     </PropertyGroup>
 
     <!-- Default properties -->


### PR DESCRIPTION
In non-web project, WebProjectOutputDir property doesn't exist. In order to make the provider work in non-web project, we need to have a fallback. In this case, we will use OutputPath property, if WebProjectOutputDir doesn't exist.