### PR TITLE
update Roslyn ref version and build.cmd

### DIFF
--- a/Build.cmd
+++ b/Build.cmd
@@ -6,16 +6,9 @@ set EnableNuGetPackageRestore=true
 
 set logOptions=/flp:Summary;Verbosity=normal;LogFile=msbuild.log /flp1:warningsonly;logfile=msbuild.wrn /flp2:errorsonly;logfile=msbuild.err
 
-REM Find the most recent 32bit MSBuild.exe on the system. Require v12.0 (installed with VS2013) or later since .NET 4.0
-REM is not supported. Always quote the %MSBuild% value when setting the variable and never quote %MSBuild% references.
-set MSBuild="%ProgramFiles(x86)%\MSBuild\14.0\Bin\MSBuild.exe"
-if not exist %MSBuild% @set MSBuild="%ProgramFiles(x86)%\MSBuild\12.0\Bin\MSBuild.exe"
-if not exist %MSBuild% (
-  echo Could not find msbuild.exe. Please run this from a Visual Studio developer prompt
-  goto BuildFail
-)
+echo Please build from VS 2015(or newer version) Developer Command Prompt
 
-%MSBuild% "%~dp0\RoslynCodeProvider.msbuild" %logOptions% /v:minimal /maxcpucount /nodeReuse:false %*
+msbuild "%~dp0\RoslynCodeProvider.msbuild" %logOptions% /v:minimal /maxcpucount /nodeReuse:false %*
 if %ERRORLEVEL% neq 0 goto BuildFail
 goto BuildSuccess
 

--- a/tools/RoslynCodeProvider.settings.targets
+++ b/tools/RoslynCodeProvider.settings.targets
@@ -13,7 +13,7 @@
 
     <PropertyGroup Label="NuGet package dependencies">
         <MSNetCompilersNuGetPackageVersion>1.3.2</MSNetCompilersNuGetPackageVersion>
-        <MSNetCompilersNuGetPackageLatestVersion>2.6.1</MSNetCompilersNuGetPackageLatestVersion>
+        <MSNetCompilersNuGetPackageLatestVersion>2.7.0</MSNetCompilersNuGetPackageLatestVersion>
     </PropertyGroup>
 
     <!-- Default properties -->


### PR DESCRIPTION
Update Roslyn ref package version to 2.7.0 and modify build.cmd to add prerequisites, running it in VS developer command prompt.