### PR TITLE
made ICompilerSettings and CSharpCodeProvider ctor public

### DIFF
--- a/src/Microsoft.CodeDom.Providers.DotNetCompilerPlatform/CSharpCodeProvider.cs
+++ b/src/Microsoft.CodeDom.Providers.DotNetCompilerPlatform/CSharpCodeProvider.cs
@@ -18,8 +18,12 @@ namespace Microsoft.CodeDom.Providers.DotNetCompilerPlatform {
             : this(null) {
         }
 
-        // Constructor used for unit test purpose
-        internal CSharpCodeProvider(ICompilerSettings compilerSettings = null) {
+        
+        /// <summary>
+        /// Creates an instance using the given ICompilerSettings
+        /// </summary>
+        /// <param name="compilerSettings"></param>
+        public CSharpCodeProvider(ICompilerSettings compilerSettings = null) {
             _compilerSettings = compilerSettings == null ? CompilationSettingsHelper.CSC2 : compilerSettings;
         }
 

--- a/src/Microsoft.CodeDom.Providers.DotNetCompilerPlatform/Util/ICompilerSettings.cs
+++ b/src/Microsoft.CodeDom.Providers.DotNetCompilerPlatform/Util/ICompilerSettings.cs
@@ -1,13 +1,21 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-﻿using System;
-
 namespace Microsoft.CodeDom.Providers.DotNetCompilerPlatform {
-    public interface ICompilerSettings {
-        string CompilerFullPath { get; }
 
-        // TTL in seconds
-        int CompilerServerTimeToLive { get; }
+	/// <summary>
+	/// Provides settings for the C# and VB CodeProviders
+	/// </summary>
+	public interface ICompilerSettings {
+
+		/// <summary>
+		/// The full path to csc.exe or vbc.exe
+		/// </summary>
+		string CompilerFullPath { get; }
+
+		/// <summary>
+		/// TTL in seconds
+		/// </summary>
+		int CompilerServerTimeToLive { get; }
     }
 }

--- a/src/Microsoft.CodeDom.Providers.DotNetCompilerPlatform/Util/ICompilerSettings.cs
+++ b/src/Microsoft.CodeDom.Providers.DotNetCompilerPlatform/Util/ICompilerSettings.cs
@@ -4,7 +4,7 @@
 ﻿using System;
 
 namespace Microsoft.CodeDom.Providers.DotNetCompilerPlatform {
-    internal interface ICompilerSettings {
+    public interface ICompilerSettings {
         string CompilerFullPath { get; }
 
         // TTL in seconds

--- a/src/Microsoft.CodeDom.Providers.DotNetCompilerPlatform/VBCodeProvider.cs
+++ b/src/Microsoft.CodeDom.Providers.DotNetCompilerPlatform/VBCodeProvider.cs
@@ -18,8 +18,11 @@ namespace Microsoft.CodeDom.Providers.DotNetCompilerPlatform {
             : this(null) {
         }
 
-        // Constructor used for unit test purpose
-        internal VBCodeProvider(ICompilerSettings compilerSettings = null) {
+		/// <summary>
+		/// Creates an instance using the given ICompilerSettings
+		/// </summary>
+		/// <param name="compilerSettings"></param>
+		public VBCodeProvider(ICompilerSettings compilerSettings = null) {
             _compilerSettings = compilerSettings == null ? CompilationSettingsHelper.VBC2 : compilerSettings;
         }
 


### PR DESCRIPTION
Its unclear why CompilationSettings doesn't allow falling back to the tooling installed on the dev environment, or to use a csc compiler from a different location that whats shipped with this assembly.

By making the ICompilerSettings interface public this becomes trivial.

I don't see any reason for this to be internal