### PR TITLE
Use a netstandard dll for build tasks instead of inline fragments. Th…

### DIFF
--- a/Build.cmd
+++ b/Build.cmd
@@ -15,7 +15,7 @@ REM set logOptions=/v:diag /flp:Summary;Verbosity=normal;LogFile=msbuild.log /fl
 
 echo Please build from VS 2015(or newer version) Developer Command Prompt
 
-%MSBUILDEXE% "%~dp0\RoslynCodeProvider.msbuild" /t:BuildAll %logOptions% /maxcpucount /nodeReuse:false %cfgOption%%*
+%MSBUILDEXE% "%~dp0\RoslynCodeProvider.msbuild" /t:Build %logOptions% /maxcpucount /nodeReuse:false %cfgOption%%*
 if %ERRORLEVEL% neq 0 goto BuildFail
 goto BuildSuccess
 

--- a/RoslynCodeProvider.msbuild
+++ b/RoslynCodeProvider.msbuild
@@ -3,20 +3,23 @@
 
   <ItemGroup>
     <AssemblyProject Include="src\Microsoft.CodeDom.Providers.DotNetCompilerPlatform\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.csproj" />
-  </ItemGroup>
-  <ItemGroup>
-    <AssemblyProject Include="RoslynCodeProviderTest\Microsoft.CodeDom.Providers.DotNetCompilerPlatformTest.csproj" />
+    <AssemblyProject Include="src\DotNetCompilerPlatformTasks\DotNetCompilerPlatformTasks.csproj" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageProject Include="src\Packages\Packages.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <TestProject Include="RoslynCodeProviderTest\Microsoft.CodeDom.Providers.DotNetCompilerPlatformTest.csproj" />
+  </ItemGroup>
+
+
   <!-- Composite targets -->
   <Target Name="BuildCI" DependsOnTargets="Clean;Build" />
 
-  <Target Name="Build" DependsOnTargets="BuildAssemblies;BuildPackages" />
-  <Target Name="Clean" DependsOnTargets="CleanPackages;CleanAssemblies" />
+  <Target Name="Build" DependsOnTargets="BuildAssemblies;BuildTests;BuildPackages" />
+  <Target Name="Clean" DependsOnTargets="CleanPackages;CleanTests;CleanAssemblies" />
   <Target Name="Rebuild" DependsOnTargets="Clean;Build" />
 
   <!-- Core build-->
@@ -25,8 +28,16 @@
     <MSBuild Targets="Build" Projects="@(AssemblyProject)" />
   </Target>
 
+  <Target Name="BuildTests" DependsOnTargets="RestorePackages">
+    <MSBuild Targets="Build" Projects="@(TestProject)" />
+  </Target>
+
   <Target Name="CleanAssemblies">
     <MSBuild Targets="Clean" Projects="@(AssemblyProject)" />
+  </Target>
+
+  <Target Name="CleanTests">
+    <MSBuild Targets="Clean" Projects="@(TestProject)" />
   </Target>
 
   <Target Name="RebuildAssemblies" DependsOnTargets="Clean;Build" />

--- a/RoslynCodeProvider.sln
+++ b/RoslynCodeProvider.sln
@@ -13,6 +13,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.CodeDom.Providers
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Packages", "src\Packages\Packages.csproj", "{7EC5863F-7FF1-41C7-A384-8FFF81531E7A}"
 	ProjectSection(ProjectDependencies) = postProject
+		{E3D81E13-7489-4064-B789-AE1B02C7C616} = {E3D81E13-7489-4064-B789-AE1B02C7C616}
 		{BE52ED6A-F180-499D-80BB-B0237B50023C} = {BE52ED6A-F180-499D-80BB-B0237B50023C}
 	EndProjectSection
 EndProject
@@ -33,6 +34,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{6EB4E0
 		.nuget\NuGet.targets = .nuget\NuGet.targets
 	EndProjectSection
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DotNetCompilerPlatformTasks", "src\DotNetCompilerPlatformTasks\DotNetCompilerPlatformTasks.csproj", "{E3D81E13-7489-4064-B789-AE1B02C7C616}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -51,6 +54,10 @@ Global
 		{7EC5863F-7FF1-41C7-A384-8FFF81531E7A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7EC5863F-7FF1-41C7-A384-8FFF81531E7A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7EC5863F-7FF1-41C7-A384-8FFF81531E7A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E3D81E13-7489-4064-B789-AE1B02C7C616}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E3D81E13-7489-4064-B789-AE1B02C7C616}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E3D81E13-7489-4064-B789-AE1B02C7C616}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E3D81E13-7489-4064-B789-AE1B02C7C616}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -59,6 +66,7 @@ Global
 		{12B521BD-F065-4F81-BD7A-D6F715B38F12} = {770A45B7-BC65-4FC4-94FF-7F99838F3219}
 		{BE52ED6A-F180-499D-80BB-B0237B50023C} = {566A9F52-15C9-4BD0-AD3A-9CC7D391834E}
 		{7EC5863F-7FF1-41C7-A384-8FFF81531E7A} = {566A9F52-15C9-4BD0-AD3A-9CC7D391834E}
+		{E3D81E13-7489-4064-B789-AE1B02C7C616} = {566A9F52-15C9-4BD0-AD3A-9CC7D391834E}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {A5B8F404-C4DF-48B5-80FE-6FC256ADCEC3}

--- a/src/DotNetCompilerPlatformTasks/Directory.Build.props
+++ b/src/DotNetCompilerPlatformTasks/Directory.Build.props
@@ -1,0 +1,7 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <PropertyGroup>
+      <BaseIntermediateOutputPath>..\..\obj</BaseIntermediateOutputPath>
+      <OutputPath>..\..\bin\$(Configuration)\</OutputPath>
+      <OutDir>$(OutputPath)</OutDir>
+    </PropertyGroup>
+  </Project>

--- a/src/DotNetCompilerPlatformTasks/DotNetCompilerPlatformTasks.csproj
+++ b/src/DotNetCompilerPlatformTasks/DotNetCompilerPlatformTasks.csproj
@@ -1,0 +1,21 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="14.3.0">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="System.Management" Version="4.5.0" />
+  </ItemGroup>
+
+</Project>

--- a/src/DotNetCompilerPlatformTasks/Tasks.cs
+++ b/src/DotNetCompilerPlatformTasks/Tasks.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Management;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace DotNetCompilerPlatformTasks
+{
+    public class KillProcess : Task
+    {
+        [Required]
+        public string ProcessName { get; set; }
+        [Required]
+        public string ImagePath { get; set; }
+
+        public override bool Execute()
+        {
+            try
+            {
+                foreach (var p in Process.GetProcessesByName(ProcessName))
+                {
+                    var wmiQuery = "SELECT ProcessId, ExecutablePath FROM Win32_Process WHERE ProcessId = " + p.Id;
+                    using (var searcher = new ManagementObjectSearcher(wmiQuery))
+                    {
+                        using (var results = searcher.Get())
+                        {
+                            var mo = results.Cast<ManagementObject>().FirstOrDefault();
+                            if (mo != null)
+                            {
+                                var path = (string)mo["ExecutablePath"];
+                                var executablePath = path != null ? path : string.Empty;
+                                Log.LogMessage("ExecutablePath is {0}", executablePath);
+
+                                if (executablePath.StartsWith(ImagePath, StringComparison.OrdinalIgnoreCase))
+                                {
+                                    p.Kill();
+                                    p.WaitForExit();
+                                    Log.LogMessage("{0} is killed", executablePath);
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.LogWarning(ex.Message);
+            }
+            return true;
+        }
+    }
+
+    public class CheckIfVBCSCompilerWillOverride : Task
+    {
+        [Required]
+        public string Src { get; set; }
+        [Required]
+        public string Dest { get; set; }
+
+        [Output]
+        public bool WillOverride { get; set; }
+
+        public override bool Execute()
+        {
+            WillOverride = false;
+
+            try
+            {
+                WillOverride = File.Exists(Src) && File.Exists(Dest) && (File.GetLastWriteTime(Src) != File.GetLastWriteTime(Dest));
+            }
+            catch { return false; }
+
+            return true;
+        }
+    }
+}

--- a/src/Packages/Microsoft.CodeDom.Providers.DotNetCompilerPlatform/Microsoft.CodeDom.Providers.DotNetCompilerPlatform.nuproj
+++ b/src/Packages/Microsoft.CodeDom.Providers.DotNetCompilerPlatform/Microsoft.CodeDom.Providers.DotNetCompilerPlatform.nuproj
@@ -20,6 +20,14 @@
             <Source>$(OutputPath)</Source>
             <Destination>lib\net45</Destination>
         </NuGetContent>
+        <NuGetContent Include="DotNetCompilerPlatformTasks.dll">
+          <Source>$(OutputPath)</Source>
+          <Destination>tasks</Destination>
+        </NuGetContent>
+        <NuGetContent Include="System.Management.dll">
+          <Source>$(OutputPath)</Source>
+          <Destination>tasks</Destination>
+        </NuGetContent>
         <NuGetContentProject Include="$(RepositoryRoot)\src\$(MSBuildProjectName)\$(MSBuildProjectName).csproj" Condition="'$(NuGetPackSymbols)' == 'true'" />
         <NuGetContent Include="Content\net45\*">
             <Destination>content\net45</Destination>

--- a/src/Packages/Microsoft.CodeDom.Providers.DotNetCompilerPlatform/build/Microsoft.CodeDom.Providers.DotNetCompilerPlatform.targets
+++ b/src/Packages/Microsoft.CodeDom.Providers.DotNetCompilerPlatform/build/Microsoft.CodeDom.Providers.DotNetCompilerPlatform.targets
@@ -48,75 +48,7 @@
     <KillProcess ProcessName="VBCSCompiler" ImagePath="$(RoslynToolsDestinationFolder)" />
   </Target>
 
-  <UsingTask TaskName="KillProcess" TaskFactory="CodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v4.0.dll">
-    <ParameterGroup>
-      <ProcessName ParameterType="System.String" Required="true" />
-      <ImagePath ParameterType="System.String" Required="true" />
-    </ParameterGroup>
-    <Task>
-      <Reference Include="System" />
-      <Reference Include="System.Management" />
-      <Using Namespace="System" />
-      <Using Namespace="System.Linq" />
-      <Using Namespace="System.Diagnostics" />
-      <Using Namespace="System.Management" />
-      <Code Type="Fragment" Language="cs">
-        <![CDATA[
-                try
-                {
-                  foreach(var p in Process.GetProcessesByName(ProcessName))
-                  {
-                      var wmiQuery = "SELECT ProcessId, ExecutablePath FROM Win32_Process WHERE ProcessId = " + p.Id;
-                      using(var searcher = new ManagementObjectSearcher(wmiQuery))
-                      {
-                        using(var results = searcher.Get())
-                          {
-                            var mo = results.Cast<ManagementObject>().FirstOrDefault();
-                            if(mo != null)
-                            {
-                              var path = (string)mo["ExecutablePath"];
-                              var executablePath = path != null ? path : string.Empty;
-                              Log.LogMessage("ExecutablePath is {0}", executablePath);
+  <UsingTask TaskName="KillProcess" AssemblyFile="..\..\tasks\DotNetCompilerPlatformTasks.dll" />
+  <UsingTask TaskName="CheckIfVBCSCompilerWillOverride" AssemblyFile="..\..\tasks\DotNetCompilerPlatformTasks.dll" />
 
-                              if(executablePath.StartsWith(ImagePath, StringComparison.OrdinalIgnoreCase))
-                              {
-                                p.Kill();
-                                p.WaitForExit();
-                                Log.LogMessage("{0} is killed", executablePath);
-                                break;
-                              }
-                            }
-                          }
-                      }
-                  }
-                }
-                catch (Exception ex)
-                {
-                  Log.LogWarning(ex.Message);
-                }
-                return true;
-                ]]>
-      </Code>
-    </Task>
-  </UsingTask>
-
-  <UsingTask TaskName="CheckIfVBCSCompilerWillOverride" TaskFactory="CodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v4.0.dll">
-    <ParameterGroup>
-      <Src ParameterType="System.String" Required="true" />
-      <Dest ParameterType="System.String" Required="true" />
-      <WillOverride ParameterType="System.Boolean" Output="true" />
-    </ParameterGroup>
-    <Task>
-      <Reference Include="System.IO" />
-      <Code Type="Fragment" Language="cs">
-        <![CDATA[
-                WillOverride = false;
-                try {
-                  WillOverride = File.Exists(Src) && File.Exists(Dest) && (File.GetLastWriteTime(Src) != File.GetLastWriteTime(Dest));
-                }
-                catch { }
-                ]]>
-      </Code>
-    </Task>
-  </UsingTask>
 </Project>


### PR DESCRIPTION
…is will allow building SDK-style full framework projects with 'dotnet build.'

This should address #51 