### PR TITLE
Upgrade package

### DIFF
--- a/RoslynCodeProviderTest/App.config
+++ b/RoslynCodeProviderTest/App.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <system.codedom>
     <compilers>
@@ -17,4 +17,4 @@
       </compiler>
     </compilers>
   </system.codedom>
-</configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/></startup></configuration>

--- a/RoslynCodeProviderTest/Microsoft.CodeDom.Providers.DotNetCompilerPlatformTest.csproj
+++ b/RoslynCodeProviderTest/Microsoft.CodeDom.Providers.DotNetCompilerPlatformTest.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.CodeDom.Providers.DotNetCompilerPlatformTest</RootNamespace>
     <AssemblyName>Microsoft.CodeDom.Providers.DotNetCompilerPlatformTest</AssemblyName>
-    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SignAssembly>true</SignAssembly>
     <DelaySign>true</DelaySign>

--- a/src/Microsoft.CodeDom.Providers.DotNetCompilerPlatform/Microsoft.CodeDom.Providers.DotNetCompilerPlatform.csproj
+++ b/src/Microsoft.CodeDom.Providers.DotNetCompilerPlatform/Microsoft.CodeDom.Providers.DotNetCompilerPlatform.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.CodeDom.Providers.DotNetCompilerPlatform</RootNamespace>
     <AssemblyName>Microsoft.CodeDom.Providers.DotNetCompilerPlatform</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SignAssembly>true</SignAssembly>
     <DelaySign>true</DelaySign>
@@ -22,6 +22,7 @@
     <DocumentationFile>$(OutputPath)$(AssemblyName).xml</DocumentationFile>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/Packages/Microsoft.CodeDom.Providers.DotNetCompilerPlatform/Microsoft.CodeDom.Providers.DotNetCompilerPlatform.nuproj
+++ b/src/Packages/Microsoft.CodeDom.Providers.DotNetCompilerPlatform/Microsoft.CodeDom.Providers.DotNetCompilerPlatform.nuproj
@@ -10,15 +10,15 @@
   <ItemGroup>
     <NuGetContent Include="$(AssemblyName).dll">
       <Source>$(AssemblyPath)</Source>
-      <Destination>lib\net45</Destination>
+      <Destination>lib\net472</Destination>
     </NuGetContent>
     <NuGetContent Include="$(AssemblyName).xml">
       <Source>$(OutputPath)</Source>
-      <Destination>lib\net45</Destination>
+      <Destination>lib\net472</Destination>
     </NuGetContent>
     <NuGetContent Include="$(AssemblyName).pdb" Condition="'$(NuGetPackSymbols)' == 'true'">
       <Source>$(OutputPath)</Source>
-      <Destination>lib\net45</Destination>
+      <Destination>lib\net472</Destination>
     </NuGetContent>
     <NuGetContentProject Include="$(RepositoryRoot)\src\$(MSBuildProjectName)\$(MSBuildProjectName).csproj" Condition="'$(NuGetPackSymbols)' == 'true'" />
     <NuGetContent Include="DotNetCompilerPlatformTasks.dll">
@@ -28,30 +28,6 @@
     <NuGetContent Include="System.Management.dll">
       <Source>$(OutputPath)</Source>
       <Destination>tasks</Destination>
-    </NuGetContent>
-    <NuGetContent Include="Content\config.install.xdt">
-      <Destination>content\net45\app.config.install.xdt</Destination>
-    </NuGetContent>
-    <NuGetContent Include="Content\config.install.xdt">
-      <Destination>content\net45\web.config.install.xdt</Destination>
-    </NuGetContent>
-    <NuGetContent Include="Content\config.uninstall.xdt">
-      <Destination>content\net45\app.config.uninstall.xdt</Destination>
-    </NuGetContent>
-    <NuGetContent Include="Content\config.uninstall.xdt">
-      <Destination>content\net45\web.config.uninstall.xdt</Destination>
-    </NuGetContent>
-    <NuGetContent Include="Content\config.install.xdt">
-      <Destination>content\net46\app.config.install.xdt</Destination>
-    </NuGetContent>
-    <NuGetContent Include="Content\config.install.xdt">
-      <Destination>content\net46\web.config.install.xdt</Destination>
-    </NuGetContent>
-    <NuGetContent Include="Content\config.uninstall.xdt">
-      <Destination>content\net46\app.config.uninstall.xdt</Destination>
-    </NuGetContent>
-    <NuGetContent Include="Content\config.uninstall.xdt">
-      <Destination>content\net46\web.config.uninstall.xdt</Destination>
     </NuGetContent>
     <NuGetContent Include="Content\config.install.xdt">
       <Destination>content\net472\app.config.install.xdt</Destination>
@@ -66,34 +42,16 @@
       <Destination>content\net472\web.config.uninstall.xdt</Destination>
     </NuGetContent>
     <NuGetContent Include="build\*">
-      <Destination>build\net45</Destination>
-    </NuGetContent>
-    <NuGetContent Include="build\*">
       <Destination>build\net472</Destination>
-    </NuGetContent>
-    <NuGetContent Include="build\*">
-      <Destination>build\net46</Destination>
-    </NuGetContent>
-    <NuGetContent Include="build\net45\*">
-      <Destination>build\net45</Destination>
-    </NuGetContent>
-    <NuGetContent Include="build\net46\*">
-      <Destination>build\net46</Destination>
     </NuGetContent>
     <NuGetContent Include="build\net472\*">
       <Destination>build\net472</Destination>
     </NuGetContent>
     <NuGetContent Include="tools\*.ps1" Condition="'$(SignAssembly)' != 'true'">
-      <Destination>tools\net45</Destination>
+      <Destination>tools\net472</Destination>
     </NuGetContent>
     <NuGetContent Include="tools\signed\*.ps1" Condition="'$(SignAssembly)' == 'true'">
-      <Destination>tools\net45</Destination>
-    </NuGetContent>
-    <NuGetContent Include="tools\$(LocalRoslyn45FolderName)\*">
-      <Destination>tools\$(LocalRoslyn45FolderName)</Destination>
-    </NuGetContent>
-    <NuGetContent Include="tools\$(LocalRoslyn46FolderName)\*">
-      <Destination>tools\$(LocalRoslyn46FolderName)</Destination>
+      <Destination>tools\net472</Destination>
     </NuGetContent>
     <NuGetContent Include="tools\$(LocalRoslyn472FolderName)\*">
       <Destination>tools\$(LocalRoslyn472FolderName)</Destination>

--- a/src/Packages/Microsoft.CodeDom.Providers.DotNetCompilerPlatform/Microsoft.CodeDom.Providers.DotNetCompilerPlatform.nuspec
+++ b/src/Packages/Microsoft.CodeDom.Providers.DotNetCompilerPlatform/Microsoft.CodeDom.Providers.DotNetCompilerPlatform.nuspec
@@ -15,7 +15,7 @@
         <language>en-US</language>
         <projectUrl>http://www.asp.net/</projectUrl>
         <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
-        <licenseUrl>http://www.microsoft.com/web/webpi/eula/net_library_eula_ENU.htm</licenseUrl>
+        <license type="expression">MIT</license>
         <requireLicenseAcceptance>true</requireLicenseAcceptance>
         <tags>Roslyn CodeDOM Compiler CSharp VB.Net ASP.NET</tags>
     </metadata>

--- a/src/Packages/Microsoft.CodeDom.Providers.DotNetCompilerPlatform/build/net45/Microsoft.CodeDom.Providers.DotNetCompilerPlatform.Extensions.targets
+++ b/src/Packages/Microsoft.CodeDom.Providers.DotNetCompilerPlatform/build/net45/Microsoft.CodeDom.Providers.DotNetCompilerPlatform.Extensions.targets
@@ -1,9 +1,0 @@
-<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-
-  <Target Name="LocateRoslynCompilerFiles">
-    <PropertyGroup>
-      <RoslynToolPath Condition="'$(RoslynToolPath)' == ''">$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)..\..\tools\roslyn45'))</RoslynToolPath>
-    </PropertyGroup>
-  </Target>
-
-</Project>

--- a/src/Packages/Microsoft.CodeDom.Providers.DotNetCompilerPlatform/build/net46/Microsoft.CodeDom.Providers.DotNetCompilerPlatform.Extensions.targets
+++ b/src/Packages/Microsoft.CodeDom.Providers.DotNetCompilerPlatform/build/net46/Microsoft.CodeDom.Providers.DotNetCompilerPlatform.Extensions.targets
@@ -1,9 +1,0 @@
-<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-
-  <Target Name="LocateRoslynCompilerFiles">
-    <PropertyGroup>
-      <RoslynToolPath Condition="'$(RoslynToolPath)' == ''">$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)..\..\tools\roslyn46'))</RoslynToolPath>
-    </PropertyGroup>
-  </Target>
-
-</Project>

--- a/src/Packages/Microsoft.CodeDom.Providers.DotNetCompilerPlatform/tools/install.ps1
+++ b/src/Packages/Microsoft.CodeDom.Providers.DotNetCompilerPlatform/tools/install.ps1
@@ -8,42 +8,26 @@
 
 param($installPath, $toolsPath, $package, $project)
 
-$assemblyVersion = '3.6.0.0'
+$assemblyVersion = '4.0.0.0'
 $roslynSubFolder = 'roslyn'
 
 if ($project -eq $null) {
     $project = Get-Project
 }
 
-$libDirectory = Join-Path $installPath 'lib\net45'
+$libDirectory = Join-Path $installPath 'lib\net472'
 $projectRoot = $project.Properties.Item('FullPath').Value
 $projectTargetFramework = $project.Properties.Item('TargetFrameworkMoniker').Value
 $binDirectory = Join-Path $projectRoot 'bin'
 
-#
-# Some things vary depending on which framework version you target. If you target an
-# older framework, (4.5-4.7.1) then we need to change some of these.
-#
 $compilerVersion = $package.Version
 if($package.Versions -ne $null) { $compilerVersion = @($package.Versions)[0] }
 $packageDirectory = Split-Path $installPath
 $compilerPackageFolderName = $package.Id + "." + $compilerVersion
 $compilerPackageDirectory = Join-Path $packageDirectory $compilerPackageFolderName
 $compilerPackageToolsDirectory = Join-Path $compilerPackageDirectory 'tools\roslyn472'
-$csLanguageVersion = '7.3'
+$csLanguageVersion = 'default'
 $vbLanguageVersion = 'default'
-if ($projectTargetFramework -match 'v4\.5')
-{
-    $compilerPackageToolsDirectory = Join-Path $compilerPackageDirectory 'tools\roslyn45'
-    $csLanguageVersion = '6'    # Leave this at 6 for compat
-    $vbLanguageVersion = '14'
-}
-elseif (($projectTargetFramework -match 'v4\.6') -or ($projectTargetFramework -match 'v4\.7[^\.]') -or ($projectTargetFramework -match 'v4\.7\.[01]'))
-{
-    $compilerPackageToolsDirectory = Join-Path $compilerPackageDirectory 'tools\roslyn46'
-    $csLanguageVersion = '7.0'  # This was 'default' which is 7.0 for this version of ms.net.compilers
-    $vbLanguageVersion = 'default'  # Is 15 for this ms.net.compilers... but will leave as 'default' for upgrades since that is still valid in .Net 4.8
-}
 
 
 # Fill out the config entries for these code dom providers here. Using powershell to do

--- a/src/Packages/Packages.csproj
+++ b/src/Packages/Packages.csproj
@@ -23,14 +23,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform\build\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.targets" />
-    <None Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform\build\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.Extensions.targets" />
-    <None Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform\build\net46\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.Extensions.targets" />
     <None Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform\build\net472\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.Extensions.targets" />
-    <None Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform\tools\Roslyn45\Microsoft.CSharp.Core.targets" />
-    <None Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform\tools\Roslyn45\Microsoft.VisualBasic.Core.targets" />
-    <None Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform\tools\Roslyn46\Microsoft.CSharp.Core.targets" />
-    <None Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform\tools\Roslyn46\Microsoft.Managed.Core.targets" />
-    <None Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform\tools\Roslyn46\Microsoft.VisualBasic.Core.targets" />
     <None Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform\tools\Roslyn472\Microsoft.CSharp.Core.targets" />
     <None Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform\tools\Roslyn472\Microsoft.Managed.Core.targets" />
     <None Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform\tools\Roslyn472\Microsoft.VisualBasic.Core.targets" />

--- a/tools/RoslynCodeProvider.Extensions.targets
+++ b/tools/RoslynCodeProvider.Extensions.targets
@@ -1,19 +1,13 @@
 <Project DefaultTargets="UnitTest" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
         <NupkgToolPath>$(RepositoryRoot)src\Packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform\tools\</NupkgToolPath>
-        <LocalRoslyn45FolderName>Roslyn45</LocalRoslyn45FolderName>
-        <LocalRoslyn46FolderName>Roslyn46</LocalRoslyn46FolderName>
         <LocalRoslyn472FolderName>Roslyn472</LocalRoslyn472FolderName>
     </PropertyGroup>
     
     <UsingTask TaskName="DownloadRoslynBinaries" TaskFactory="CodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v4.0.dll">
     <ParameterGroup>
       <NupkgToolPath ParameterType="System.String" Required="true" />
-      <LocalRoslyn45FolderName ParameterType="System.String" Required="true" />
-      <LocalRoslyn46FolderName ParameterType="System.String" Required="true" />
       <LocalRoslyn472FolderName ParameterType="System.String" Required="true" />
-      <ReferenceRoslyn45NupkgVersion ParameterType="System.String" Required="true" />
-      <ReferenceRoslyn46NupkgVersion ParameterType="System.String" Required="true" />
       <ReferenceRoslyn472NupkgVersion ParameterType="System.String" Required="true" />
     </ParameterGroup>
     <Task>
@@ -28,60 +22,12 @@
                 {
                    using (var wc = new WebClient())
                     {
-                        var roslynNugetBaseUri = "https://api.nuget.org/packages/microsoft.net.compilers.{0}.nupkg";
-                        var roslynPackageName = "microsoft.net.compilers.{0}.nupkg";
+                        var roslynNugetBaseUri = "https://api.nuget.org/packages/microsoft.net.compilers.toolset.{0}.nupkg";
+                        var roslynPackageName = "microsoft.net.compilers.toolset.{0}.nupkg";
 
-                        var targetFilePath = Path.Combine(Path.GetTempPath(), string.Format(roslynPackageName, ReferenceRoslyn45NupkgVersion));
-                        var targetExtractPath = Path.Combine(Path.GetTempPath(), LocalRoslyn45FolderName);
-                        var packageToolsPath = Path.Combine(NupkgToolPath, LocalRoslyn45FolderName);
-                        if (Directory.Exists(targetExtractPath))
-                        {
-                            Directory.Delete(targetExtractPath, true);
-                        }
-                        if (Directory.Exists(packageToolsPath))
-                        {
-                            Directory.Delete(packageToolsPath, true);
-                        }
-
-                        wc.DownloadFile(string.Format(roslynNugetBaseUri, ReferenceRoslyn45NupkgVersion), targetFilePath);
-                        Log.LogMessage("Microsoft.Net.Compilers.{0}.nupkg is downloaded", ReferenceRoslyn45NupkgVersion);
-                        
-                        ZipFile.ExtractToDirectory(targetFilePath, targetExtractPath);
-                        Directory.CreateDirectory(packageToolsPath);
-                        foreach(var file in Directory.GetFiles(Path.Combine(targetExtractPath, "tools"))){
-                            var fi = new FileInfo(file);
-                            File.Copy(file, Path.Combine(packageToolsPath, fi.Name));
-                        }
-
-                        targetFilePath = Path.Combine(Path.GetTempPath(), string.Format(roslynPackageName, ReferenceRoslyn46NupkgVersion));
-                        targetExtractPath = Path.Combine(Path.GetTempPath(), LocalRoslyn46FolderName);
-                        packageToolsPath = Path.Combine(NupkgToolPath, LocalRoslyn46FolderName);
-                        if (Directory.Exists(targetExtractPath))
-                        {
-                            Directory.Delete(targetExtractPath, true);
-                        }
-                        if (Directory.Exists(packageToolsPath))
-                        {
-                            Directory.Delete(packageToolsPath, true);
-                        }
-
-                        wc.DownloadFile(string.Format(roslynNugetBaseUri, ReferenceRoslyn46NupkgVersion), targetFilePath);
-                        Log.LogMessage("Microsoft.Net.Compilers.{0}.nupkg is downloaded", ReferenceRoslyn46NupkgVersion);
-
-                        ZipFile.ExtractToDirectory(targetFilePath, targetExtractPath);
-                        Directory.CreateDirectory(packageToolsPath);
-                        foreach (var file in Directory.GetFiles(Path.Combine(targetExtractPath, "tools")))
-                        {
-                            var fi = new FileInfo(file);
-                            File.Copy(file, Path.Combine(packageToolsPath, fi.Name));
-                        }
-
-                        roslynNugetBaseUri = "https://api.nuget.org/packages/microsoft.net.compilers.toolset.{0}.nupkg";
-                        roslynPackageName = "microsoft.net.compilers.toolset.{0}.nupkg";
-
-                        targetFilePath = Path.Combine(Path.GetTempPath(), string.Format(roslynPackageName, ReferenceRoslyn472NupkgVersion));
-                        targetExtractPath = Path.Combine(Path.GetTempPath(), LocalRoslyn472FolderName);
-                        packageToolsPath = Path.Combine(NupkgToolPath, LocalRoslyn472FolderName);
+                        var targetFilePath = Path.Combine(Path.GetTempPath(), string.Format(roslynPackageName, ReferenceRoslyn472NupkgVersion));
+                        var targetExtractPath = Path.Combine(Path.GetTempPath(), LocalRoslyn472FolderName);
+                        var packageToolsPath = Path.Combine(NupkgToolPath, LocalRoslyn472FolderName);
                         if (Directory.Exists(targetExtractPath))
                         {
                             Directory.Delete(targetExtractPath, true);

--- a/tools/RoslynCodeProvider.Extensions.targets
+++ b/tools/RoslynCodeProvider.Extensions.targets
@@ -75,7 +75,10 @@
                             var fi = new FileInfo(file);
                             File.Copy(file, Path.Combine(packageToolsPath, fi.Name));
                         }
-                        
+
+                        roslynNugetBaseUri = "https://api.nuget.org/packages/microsoft.net.compilers.toolset.{0}.nupkg";
+                        roslynPackageName = "microsoft.net.compilers.toolset.{0}.nupkg";
+
                         targetFilePath = Path.Combine(Path.GetTempPath(), string.Format(roslynPackageName, ReferenceRoslyn472NupkgVersion));
                         targetExtractPath = Path.Combine(Path.GetTempPath(), LocalRoslyn472FolderName);
                         packageToolsPath = Path.Combine(NupkgToolPath, LocalRoslyn472FolderName);
@@ -89,11 +92,11 @@
                         }
 
                         wc.DownloadFile(string.Format(roslynNugetBaseUri, ReferenceRoslyn472NupkgVersion), targetFilePath);
-                        Log.LogMessage("Microsoft.Net.Compilers.{0}.nupkg is downloaded", ReferenceRoslyn472NupkgVersion);
+                        Log.LogMessage("Microsoft.Net.Compilers.Toolset.{0}.nupkg is downloaded", ReferenceRoslyn472NupkgVersion);
 
                         ZipFile.ExtractToDirectory(targetFilePath, targetExtractPath);
                         Directory.CreateDirectory(packageToolsPath);
-                        foreach (var file in Directory.GetFiles(Path.Combine(targetExtractPath, "tools")))
+                        foreach (var file in Directory.GetFiles(Path.Combine(targetExtractPath, "tasks/net472")))
                         {
                             var fi = new FileInfo(file);
                             File.Copy(file, Path.Combine(packageToolsPath, fi.Name));

--- a/tools/RoslynCodeProvider.settings.targets
+++ b/tools/RoslynCodeProvider.settings.targets
@@ -11,15 +11,13 @@
 
     <PropertyGroup>
         <BuildQuality Condition="'$(BuildQuality)' == ''">rtm</BuildQuality>
-        <VersionStartYear>2020</VersionStartYear>
-        <VersionMajor>3</VersionMajor>
-        <VersionMinor>6</VersionMinor>
+        <VersionStartYear>2021</VersionStartYear>
+        <VersionMajor>4</VersionMajor>
+        <VersionMinor>0</VersionMinor>
         <VersionRelease>0</VersionRelease>
     </PropertyGroup>
 
     <PropertyGroup Label="NuGet package dependencies">
-        <MSNetCompilers45NuGetPackageVersion>1.3.2</MSNetCompilers45NuGetPackageVersion>
-        <MSNetCompilers46NuGetPackageVersion>2.10.0</MSNetCompilers46NuGetPackageVersion>
         <MSNetCompilers472NuGetPackageVersion>4.0.1</MSNetCompilers472NuGetPackageVersion>
     </PropertyGroup>
 

--- a/tools/RoslynCodeProvider.settings.targets
+++ b/tools/RoslynCodeProvider.settings.targets
@@ -20,7 +20,7 @@
     <PropertyGroup Label="NuGet package dependencies">
         <MSNetCompilers45NuGetPackageVersion>1.3.2</MSNetCompilers45NuGetPackageVersion>
         <MSNetCompilers46NuGetPackageVersion>2.10.0</MSNetCompilers46NuGetPackageVersion>
-        <MSNetCompilers472NuGetPackageVersion>3.6.0</MSNetCompilers472NuGetPackageVersion>
+        <MSNetCompilers472NuGetPackageVersion>4.0.1</MSNetCompilers472NuGetPackageVersion>
     </PropertyGroup>
 
   <Target Name="SuperClean" AfterTargets="Clean"  Condition="'$(MSBuildProjectExtension)' != '.nuproj'">

--- a/tools/RoslynCodeProvider.targets
+++ b/tools/RoslynCodeProvider.targets
@@ -33,7 +33,6 @@
     <!-- We really only need to do this in the Packages project. It's superfluous and causing intermittent
         build errors in all the other projects. -->
     <Target Name="DownloadRoslynBinariesToToolsFolder" Condition="'$(MSBuildProjectExtension)' == '.nuproj'">
-        <DownloadRoslynBinaries NupkgToolPath="$(NupkgToolPath)" LocalRoslyn45FolderName="$(LocalRoslyn45FolderName)" LocalRoslyn46FolderName="$(LocalRoslyn46FolderName)" LocalRoslyn472FolderName="$(LocalRoslyn472FolderName)" 
-            ReferenceRoslyn45NupkgVersion="$(MSNetCompilers45NuGetPackageVersion)" ReferenceRoslyn46NupkgVersion="$(MSNetCompilers46NuGetPackageVersion)" ReferenceRoslyn472NupkgVersion="$(MSNetCompilers472NuGetPackageVersion)" />
+        <DownloadRoslynBinaries NupkgToolPath="$(NupkgToolPath)" LocalRoslyn472FolderName="$(LocalRoslyn472FolderName)" ReferenceRoslyn472NupkgVersion="$(MSNetCompilers472NuGetPackageVersion)" />
     </Target>
 </Project>


### PR DESCRIPTION
* Remove obsolete platforms (.Net Framework 4.5 and 4.6)
* Compile package with .Net Framework 4.7.2
* Use latest stable compiler version (4.0.1) via Microsoft.Net.Compilers.Toolset package
* Fix license in NuSpec file
* Allow the use of C# 10