### PR TITLE
Update nuget license to match this github and the Microsoft.Net.Compi…

### DIFF
--- a/src/Packages/Microsoft.CodeDom.Providers.DotNetCompilerPlatform/Microsoft.CodeDom.Providers.DotNetCompilerPlatform.nuspec
+++ b/src/Packages/Microsoft.CodeDom.Providers.DotNetCompilerPlatform/Microsoft.CodeDom.Providers.DotNetCompilerPlatform.nuspec
@@ -15,7 +15,7 @@
         <language>en-US</language>
         <projectUrl>http://www.asp.net/</projectUrl>
         <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
-        <licenseUrl>http://www.microsoft.com/web/webpi/eula/net_library_eula_ENU.htm</licenseUrl>
+        <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
         <requireLicenseAcceptance>true</requireLicenseAcceptance>
         <tags>Roslyn CodeDOM Compiler CSharp VB.Net ASP.NET</tags>
     </metadata>


### PR DESCRIPTION
The license for this github repo is MIT.
The license for the Microsoft.Net.Compiler github repo is MIT.
The license for the Microsoft.Net.Compiler nuget package is MIT.

The nupkg we produce should be MIT as well, and the fact that it wasn't is probably just an oversight.
