### PR TITLE
Handle OutDir when building in msbuild instead of VS.

### DIFF
--- a/src/Packages/Microsoft.CodeDom.Providers.DotNetCompilerPlatform/build/Microsoft.CodeDom.Providers.DotNetCompilerPlatform.targets
+++ b/src/Packages/Microsoft.CodeDom.Providers.DotNetCompilerPlatform/build/Microsoft.CodeDom.Providers.DotNetCompilerPlatform.targets
@@ -1,6 +1,10 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.Extensions.targets"/>
 
+  <PropertyGroup>
+    <RoslynCopyToOutDir>true</RoslynCopyToOutDir>
+  </PropertyGroup>
+
   <Target Name="SetRoslynCompilerFiles" DependsOnTargets="LocateRoslynCompilerFiles">
     <Message Text="Using Roslyn from '$(RoslynToolPath)' folder" />
     <ItemGroup>
@@ -21,14 +25,20 @@
   </Target>
 
   <Target Name="LocateRoslynToolsDestinationFolder" Condition=" '$(RoslynToolsDestinationFolder)' == '' ">
-    <PropertyGroup>
-      <RoslynToolsDestinationFolder>$(WebProjectOutputDir)\bin\roslyn</RoslynToolsDestinationFolder>
-      <RoslynToolsDestinationFolder Condition=" '$(WebProjectOutputDir)' == '' ">$(OutputPath)\roslyn</RoslynToolsDestinationFolder>
-    </PropertyGroup>
+    <!-- Choose one of WebProjectOutputDir or OutputPath -->
+    <!-- But when OutDir is specified given and is different from that choice, also include it without 'bin' -->
+    <ItemGroup Condition="'$(WebProjectOutputDir)' != ''">
+      <RoslynToolsDestinations Include="$(WebProjectOutputDir)\bin\roslyn" />
+      <RoslynToolsDestinations Condition="'$(RoslynCopyToOutDir)' == 'true' AND '$(OutDir)' != '$(WebProjectOutputDir)'" Include="$(OutDir)\roslyn" />
+    </ItemGroup>
+    <ItemGroup Condition="'$(WebProjectOutputDir)' == ''">
+      <RoslynToolsDestinations Include="$(OutputPath)\bin\roslyn" />
+      <RoslynToolsDestinations Condition="'$(RoslynCopyToOutDir)' == 'true' AND '$(OutDir)' != '$(OutputPath)'" Include="$(OutDir)\roslyn" />
+    </ItemGroup>
   </Target>
 
   <Target Name="CopyRoslynCompilerFilesToOutputDirectory" AfterTargets="CopyFilesToOutputDirectory" DependsOnTargets="LocateRoslynToolsDestinationFolder;SetRoslynCompilerFiles">
-    <Copy SourceFiles="@(RoslynCompilerFiles)" DestinationFolder="$(RoslynToolsDestinationFolder)" ContinueOnError="true" SkipUnchangedFiles="true" Retries="0" />
+    <Copy SourceFiles="@(RoslynCompilerFiles)" DestinationFolder="%(RoslynToolsDestinations.FullPath)" ContinueOnError="true" SkipUnchangedFiles="true" Retries="0" />
     <ItemGroup  Condition="'$(MSBuildLastTaskResult)' == 'True'" >
       <FileWrites Include="$(RoslynToolsDestinationFolder)\*" />
     </ItemGroup>


### PR DESCRIPTION
MSBuild introduced a new 'OutDir' parameter quite some time ago. It is supposed to be "the truth" for determining
where build output should go. Turns out, it just causes folks a lot of confusion. 'OutDir' might be specified. It might
not. It might be different from our old friend 'OutputPath' and it might not. And let's not get started on
'WebProjectOutputDir'.

Our binary actually gets placed in all the locations it needs to be since VS/msbuild see us as a reference, they just
do the right thing. But we want to have the 'roslyn' folder we generate to follow us as well. With this change, if
'OutDir' is specified, and it is different from the old methods for directing output, then we will copy 'roslyn' into
both destinations.