### PR TITLE
Treat non-web apps as first class, not requiring appSettings hack.

### DIFF
--- a/RoslynCodeProviderTest/ProviderOptionsTests.cs
+++ b/RoslynCodeProviderTest/ProviderOptionsTests.cs
@@ -34,7 +34,7 @@ namespace Microsoft.CodeDom.Providers.DotNetCompilerPlatformTest {
         {
             IProviderOptions opts = CompilationUtil.GetProviderOptionsFor(".fakevb");
             Assert.IsNotNull(opts);
-            Assert.AreEqual<string>(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, @"bin\roslyn"), opts.CompilerFullPath);   // Would include csc.exe or vbc.exe if the extension we searched for wasn't fake.
+            Assert.AreEqual<string>(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, @"roslyn"), opts.CompilerFullPath);   // Would include csc.exe or vbc.exe if the extension we searched for wasn't fake.
             Assert.AreEqual<int>(IsDev ? 15 * 60 : 10, opts.CompilerServerTimeToLive);   // 10 in Production. 900 in a "dev" environment.
             Assert.IsTrue(opts.UseAspNetSettings);  // Default is false... except through the GetProviderOptionsFor factory method we used here.
             Assert.IsFalse(opts.WarnAsError);
@@ -143,7 +143,7 @@ namespace Microsoft.CodeDom.Providers.DotNetCompilerPlatformTest {
             Environment.SetEnvironmentVariable("VBCSCOMPILER_TTL", null);
 
             Assert.IsNotNull(opts);
-            Assert.AreEqual<string>(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, @"bin\roslyn"), opts.CompilerFullPath);   // Would include csc.exe or vbc.exe if the extension we searched for wasn't fake.
+            Assert.AreEqual<string>(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, @"roslyn"), opts.CompilerFullPath);   // Would include csc.exe or vbc.exe if the extension we searched for wasn't fake.
             Assert.AreEqual<int>(IsDev ? 15 * 60 : 10, opts.CompilerServerTimeToLive);   // 10 in Production. 900 in a "dev" environment.
             Assert.IsTrue(opts.UseAspNetSettings);  // Default is false... except through the GetProviderOptionsFor factory method we used here.
             Assert.IsFalse(opts.WarnAsError);

--- a/src/Microsoft.CodeDom.Providers.DotNetCompilerPlatform/Util/CompilationUtil.cs
+++ b/src/Microsoft.CodeDom.Providers.DotNetCompilerPlatform/Util/CompilationUtil.cs
@@ -46,7 +46,7 @@ namespace Microsoft.CodeDom.Providers.DotNetCompilerPlatform {
             if (String.IsNullOrEmpty(compilerFullPath))
                 options.TryGetValue("CompilerLocation", out compilerFullPath);
             if (String.IsNullOrEmpty(compilerFullPath))
-                compilerFullPath = CompilerFullPath(@"bin\roslyn");
+                compilerFullPath = CompilerDefaultPath();
 
             if (fileExt.Equals(".cs", StringComparison.InvariantCultureIgnoreCase))
                 compilerFullPath = Path.Combine(compilerFullPath, "csc.exe");
@@ -143,9 +143,18 @@ namespace Microsoft.CodeDom.Providers.DotNetCompilerPlatform {
             }
         }
 
-        internal static string CompilerFullPath(string relativePath)
+        internal static string CompilerDefaultPath()
         {
-            string compilerFullPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, relativePath);
+            string webPath = @"bin\roslyn";
+            string appPath = @"roslyn";
+
+            // Check bin folder first
+            string compilerFullPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, webPath);
+
+            // Then appdomain base
+            if (!File.Exists(compilerFullPath))
+                compilerFullPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, appPath);
+
             return compilerFullPath;
         }
 

--- a/src/Packages/Microsoft.CodeDom.Providers.DotNetCompilerPlatform/build/Microsoft.CodeDom.Providers.DotNetCompilerPlatform.targets
+++ b/src/Packages/Microsoft.CodeDom.Providers.DotNetCompilerPlatform/build/Microsoft.CodeDom.Providers.DotNetCompilerPlatform.targets
@@ -29,10 +29,10 @@
     <!-- But when OutDir is specified given and is different from the above, copy to OutDir as well -->
     <ItemGroup Condition="'$(WebProjectOutputDir)' != ''">
       <RoslynToolsDestinations Include="$(WebProjectOutputDir)\bin\roslyn" />
-      <RoslynToolsDestinations Condition="'$(RoslynCopyToOutDir)' == 'true' AND '$(OutDir)' != '$(WebProjectOutputDir)'" Include="$(OutDir)\bin\roslyn" />
+      <RoslynToolsDestinations Condition="'$(RoslynCopyToOutDir)' == 'true' AND '$(OutDir)' != '$(WebProjectOutputDir)'" Include="$(OutDir)\roslyn" />
     </ItemGroup>
     <ItemGroup Condition="'$(WebProjectOutputDir)' == ''">
-      <RoslynToolsDestinations Include="$(OutputPath)\bin\roslyn" />
+      <RoslynToolsDestinations Include="$(OutputPath)\roslyn" />
       <RoslynToolsDestinations Condition="'$(RoslynCopyToOutDir)' == 'true' AND '$(OutDir)' != '$(OutputPath)'" Include="$(OutDir)\roslyn" />
     </ItemGroup>
   </Target>


### PR DESCRIPTION
In the 3.6 update, we botched the handling of the "aspnet:RoslynCompilerLocation" appSetting. Prior to that version, we
would add that value to app.config files, but not web.config. With the update, we started treating all config files the same,
not adding that setting anymore.

Web apps have a 'bin' directory where all their assemblies get deployed. We also deploy roslyn to this bin directory.
Non-web apps don't have 'bin', but instead just a base AppDomain directory. This is where we deploy roslyn in non-web scenarios.

Instead of requiring a silly 'aspnet:*' appSetting for non-aspnet apps to use this package, let's just check the appdomain base
directory as a default location.