### PR TITLE
Fixed MSBuild 17.7 issue.

### DIFF
--- a/src/Packages/Microsoft.CodeDom.Providers.DotNetCompilerPlatform/build/Microsoft.CodeDom.Providers.DotNetCompilerPlatform.targets
+++ b/src/Packages/Microsoft.CodeDom.Providers.DotNetCompilerPlatform/build/Microsoft.CodeDom.Providers.DotNetCompilerPlatform.targets
@@ -10,7 +10,7 @@
     <Message Text="Using Roslyn from '$(RoslynToolPath)' folder" />
     <ItemGroup>
       <CompilerFilesToInclude Include="$(RoslynToolPath)\**\*" />
-      <RoslynCompilerFiles Include="@(CompilerFilesToInclude )">
+      <RoslynCompilerFiles Include="@(CompilerFilesToInclude)">
         <Link>roslyn\%(RecursiveDir)%(Filename)%(Extension)</Link>
       </RoslynCompilerFiles>
     </ItemGroup>

--- a/src/Packages/Microsoft.CodeDom.Providers.DotNetCompilerPlatform/build/Microsoft.CodeDom.Providers.DotNetCompilerPlatform.targets
+++ b/src/Packages/Microsoft.CodeDom.Providers.DotNetCompilerPlatform/build/Microsoft.CodeDom.Providers.DotNetCompilerPlatform.targets
@@ -9,7 +9,10 @@
   <Target Name="SetRoslynCompilerFiles" >
     <Message Text="Using Roslyn from '$(RoslynToolPath)' folder" />
     <ItemGroup>
-      <RoslynCompilerFiles Include="$(RoslynToolPath)\**\*" />
+      <CompilerFilesToInclude Include="$(RoslynToolPath)\**\*" />
+      <RoslynCompilerFiles Include="@(CompilerFilesToInclude )">
+        <Link>roslyn\%(RecursiveDir)%(Filename)%(Extension)</Link>
+      </RoslynCompilerFiles>
     </ItemGroup>
   </Target>
 

--- a/src/Packages/Microsoft.CodeDom.Providers.DotNetCompilerPlatform/build/Microsoft.CodeDom.Providers.DotNetCompilerPlatform.targets
+++ b/src/Packages/Microsoft.CodeDom.Providers.DotNetCompilerPlatform/build/Microsoft.CodeDom.Providers.DotNetCompilerPlatform.targets
@@ -9,9 +9,7 @@
   <Target Name="SetRoslynCompilerFiles" >
     <Message Text="Using Roslyn from '$(RoslynToolPath)' folder" />
     <ItemGroup>
-      <RoslynCompilerFiles Include="$(RoslynToolPath)\*">
-        <Link>roslyn\%(RecursiveDir)%(Filename)%(Extension)</Link>
-      </RoslynCompilerFiles>
+      <RoslynCompilerFiles Include="$(RoslynToolPath)\**\*" />
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
This should fix an issue with newer versions of msbuid for both .NET SDK style and non-SDK style projects all in one.

Fixes #154.