### PR TITLE
Switch to new 'Toolset' package for getting Roslyn bits.

### DIFF
--- a/Clean.cmd
+++ b/Clean.cmd
@@ -18,6 +18,9 @@ rd /q /s tools
 rd /q /s tasks
 rd /q /s build.pp
 popd
+pushd %~dp0\src\Packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.WebSites
+rd /q /s tools.pp
+popd
 rd /q /s bin
 rd /q /s obj
 del /F msbuild.*

--- a/RoslynCodeProviderTest/CommonCodeDomProviderTests.cs
+++ b/RoslynCodeProviderTest/CommonCodeDomProviderTests.cs
@@ -12,8 +12,8 @@ namespace Microsoft.CodeDom.Providers.DotNetCompilerPlatformTest {
 
     public class CommonCodeDomProviderTests
     {
-        public static readonly Version ExpectedVersion = new Version(4, 1, 0, 0); // Maj, Min, Build, Rev
-        public static readonly string ExpectedNugetVersion = "4.1.0";
+        public static readonly Version ExpectedVersion = new Version(4, 5, 0, 0); // Maj, Min, Build, Rev
+        public static readonly string ExpectedNugetVersion = "4.5.0";
 
         private const int Failed = 1;
         private const int Success = 0;

--- a/RoslynCodeProviderTest/PackageVerificationTests.cs
+++ b/RoslynCodeProviderTest/PackageVerificationTests.cs
@@ -77,6 +77,21 @@ namespace Microsoft.CodeDom.Providers.DotNetCompilerPlatformTest
             var contentFiles = VerifyPlatforms(_fixture.WebSitesZip, "content/", new[] { "net472" }, exclusive: true);
             VerifyAllowedExtensions(contentFiles, new[] { ".xdt" });
             Assert.Equal(2, contentFiles.Count);
+
+            var scriptTools = _fixture.WebSitesZip.Entries
+                .Where(e => e.FullName.StartsWith("tools/", StringComparison.OrdinalIgnoreCase))
+                .ToList();
+            VerifyAllowedExtensions(scriptTools, new[] { ".ps1" });
+            Assert.Equal(3, scriptTools.Count);
+
+            foreach (var script in scriptTools)
+            {
+                using (var reader = new StreamReader(script.Open()))
+                {
+                    var content = reader.ReadToEnd();
+                    Assert.DoesNotContain("$providerVersion$", content, StringComparison.OrdinalIgnoreCase);
+                }
+            }
         }
 
         [Fact]

--- a/src/Packages/Microsoft.CodeDom.Providers.DotNetCompilerPlatform.WebSites/Microsoft.CodeDom.Providers.DotNetCompilerPlatform.WebSites.nuproj
+++ b/src/Packages/Microsoft.CodeDom.Providers.DotNetCompilerPlatform.WebSites/Microsoft.CodeDom.Providers.DotNetCompilerPlatform.WebSites.nuproj
@@ -7,6 +7,20 @@
     <NuSpecFile>$(MSBuildProjectName).nuspec</NuSpecFile>
     <NuGetPackSymbols>false</NuGetPackSymbols>
   </PropertyGroup>
+
+  <!-- Preprocess token replacement in some content before packing -->
+  <ItemGroup>
+    <PropertiesToReplace Include="providerVersion">
+      <Value>$(AssemblyVersion)</Value>
+    </PropertiesToReplace>
+  </ItemGroup>
+  <ItemGroup>
+    <NuGetPackageBuildTargets Include="tools\*.ps1" />
+  </ItemGroup>
+  <Target Name="PreprocessNuGetScripts" BeforeTargets="GetNugetContentFromProject">
+    <PreprocessFiles Files="@(NuGetPackageBuildTargets)" OutputDir="tools.pp" PropertyCollection="@(PropertiesToReplace)" />
+  </Target>
+  
   <ItemGroup>
     <NuGetContentProject Include="$(RepositoryRoot)\src\DotNetCompilerPlatform\DotNetCompilerPlatform.csproj" />
     <NuGetContent Include="Content\web.config.install.xdt">
@@ -15,10 +29,10 @@
     <NuGetContent Include="Content\web.config.uninstall.xdt">
       <Destination>content\net472\web.config.uninstall.xdt</Destination>
     </NuGetContent>
-    <NuGetContent Include="tools\*.ps1" Condition="'$(SignAssembly)' != 'true'">
+    <NuGetContent Include="tools.pp\*.ps1" Condition="'$(SignAssembly)' != 'true'">
       <Destination>tools</Destination>
     </NuGetContent>
-    <NuGetContent Include="tools\signed\*.ps1" Condition="'$(SignAssembly)' == 'true'">
+    <NuGetContent Include="tools.pp\signed\*.ps1" Condition="'$(SignAssembly)' == 'true'">
       <Destination>tools</Destination>
     </NuGetContent>
     <NuGetContent Include="Readme.md">

--- a/tools/RoslynCodeProvider.Extensions.targets
+++ b/tools/RoslynCodeProvider.Extensions.targets
@@ -22,8 +22,8 @@
                 {
                    using (var wc = new WebClient())
                     {
-                        var roslynNugetBaseUri = "https://api.nuget.org/packages/microsoft.net.compilers.{0}.nupkg";
-                        var roslynPackageName = "microsoft.net.compilers.{0}.nupkg";
+                        var roslynNugetBaseUri = "https://api.nuget.org/packages/microsoft.net.compilers.toolset.{0}.nupkg";
+                        var roslynPackageName = "microsoft.net.compilers.toolset.{0}.nupkg";
 
                         var targetFilePath = Path.Combine(Path.GetTempPath(), string.Format(roslynPackageName, ReferenceRoslynNupkgVersion));
                         var targetExtractPath = Path.Combine(Path.GetTempPath(), LocalRoslynFolderName);
@@ -38,11 +38,11 @@
                         }
 
                         wc.DownloadFile(string.Format(roslynNugetBaseUri, ReferenceRoslynNupkgVersion), targetFilePath);
-                        Log.LogMessage("Microsoft.Net.Compilers.{0}.nupkg is downloaded", ReferenceRoslynNupkgVersion);
+                        Log.LogMessage("Microsoft.Net.Compilers.toolset.{0}.nupkg is downloaded", ReferenceRoslynNupkgVersion);
 
                         ZipFile.ExtractToDirectory(targetFilePath, targetExtractPath);
                         Directory.CreateDirectory(packageToolsPath);
-                        foreach (var file in Directory.GetFiles(Path.Combine(targetExtractPath, "tools")))
+                        foreach (var file in Directory.GetFiles(Path.Combine(targetExtractPath, "tasks", "net472")))
                         {
                             var fi = new FileInfo(file);
                             File.Copy(file, Path.Combine(packageToolsPath, fi.Name));

--- a/tools/RoslynCodeProvider.settings.targets
+++ b/tools/RoslynCodeProvider.settings.targets
@@ -2,6 +2,7 @@
 
   <!-- Configurable properties-->
   <PropertyGroup>
+    <_PreventVersionPropertyCaching>$([System.DateTime]::Now.Ticks)</_PreventVersionPropertyCaching>
     <!-- Versioning:
             Major:	'Major' for Assembly, File, Info, and Package.
             Minor:	'Minor' for Assembly, File, Info, and Package.
@@ -15,14 +16,14 @@
     <BuildQuality Condition="'$(BuildQuality)' == ''">rtm</BuildQuality>
     <VersionStartYear>2025</VersionStartYear>
     <VersionMajor>4</VersionMajor>
-    <VersionMinor>1</VersionMinor>
+    <VersionMinor>5</VersionMinor>
     <VersionRevision>0</VersionRevision>
     <VersionRelease>0</VersionRelease>
     <VersionBuild>0</VersionBuild>
   </PropertyGroup>
 
   <PropertyGroup Label="NuGet package dependencies">
-    <MSNetCompilersNuGetPackageVersion>4.1.0</MSNetCompilersNuGetPackageVersion>
+    <MSNetCompilersNuGetPackageVersion>4.5.0</MSNetCompilersNuGetPackageVersion>
   </PropertyGroup>
 
   <!-- Common Properties & Imports -->


### PR DESCRIPTION
Pick 4.5 as the starting point, since it seems to have broad distribution.