### PR TITLE
Fix targets file to correctly identify and copy roslyn binaries.

### DIFF
--- a/src/Packages/Microsoft.CodeDom.Providers.DotNetCompilerPlatform/build/Microsoft.CodeDom.Providers.DotNetCompilerPlatform.targets
+++ b/src/Packages/Microsoft.CodeDom.Providers.DotNetCompilerPlatform/build/Microsoft.CodeDom.Providers.DotNetCompilerPlatform.targets
@@ -9,9 +9,8 @@
   <Target Name="SetRoslynCompilerFiles" >
     <Message Text="Using Roslyn from '$(RoslynToolPath)' folder" />
     <ItemGroup>
-      <RoslynCompilerFiles Include="$(RoslynToolPath)\*">
-        <Link>roslyn\%(RecursiveDir)%(Filename)%(Extension)</Link>
-      </RoslynCompilerFiles>
+      <_RoslynCompilerFilesList Include='$(RoslynToolPath)\**\*' />
+      <RoslynCompilerFiles Include='@(_RoslynCompilerFilesList)' Link="%(RecursiveDir)%(Filename)%(Extension)" />
     </ItemGroup>
   </Target>
 
@@ -39,9 +38,9 @@
   </Target>
 
   <Target Name="CopyRoslynCompilerFilesToOutputDirectory" AfterTargets="CopyFilesToOutputDirectory" DependsOnTargets="LocateRoslynToolsDestinationFolder;SetRoslynCompilerFiles" Condition="$(RoslynCopyToOutDir) == 'true'">
-    <Copy SourceFiles="@(RoslynCompilerFiles)" DestinationFolder="$(RoslynToolsDestinationFolder)" ContinueOnError="true" SkipUnchangedFiles="true" Retries="0" />
+    <Copy SourceFiles="@(RoslynCompilerFiles)" DestinationFiles="@(RoslynCompilerFiles -> '$(RoslynToolsDestinationFolder)\%(Link)')" ContinueOnError="true" SkipUnchangedFiles="true" Retries="0" />
     <ItemGroup  Condition="'$(MSBuildLastTaskResult)' == 'True'" >
-      <FileWrites Include="$(RoslynToolsDestinationFolder)\*" />
+      <FileWrites Include="$(RoslynToolsDestinationFolder)\**\*" />
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
Our targets file was failing to correctly identify and copy roslyn files to the output directory. #154

See also: https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-batching?view=vs-2022#item-batching-on-self-referencing-metadata